### PR TITLE
Include the version in released image filenames

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,10 +79,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: betaflight-bridge-${{ matrix.board }}
-          path: dist/betaflight-bridge-${{ matrix.board }}.bin
+          path: dist/betaflight-bridge-${{ matrix.board }}*.bin
 
       - name: Attach to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/betaflight-bridge-${{ matrix.board }}.bin
+          files: dist/betaflight-bridge-${{ matrix.board }}*.bin

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ IDF_TARGET := esp32s3
 # published per-board image is dist/$(PROJECT)-<board>.bin.
 PROJECT := betaflight-bridge
 
+# Firmware version. Single source of truth is the BRIDGE_VERSION #define in
+# src/main/version.h; we read it so an unversioned `make <board>` still stamps
+# and names the artefact with the coded default. Override with `make <board>
+# VERSION=x.y.z` (the release workflow passes the tag).
+VERSION ?= $(shell sed -n 's/^[[:space:]]*#define[[:space:]]\+BRIDGE_VERSION[[:space:]]\+"\(.*\)".*/\1/p' src/main/version.h)
+
 # Discover boards from the directory list — never hardcoded. Anything under
 # boards/ with an sdkconfig.defaults is a valid target.
 BOARDS := $(sort $(notdir $(patsubst %/sdkconfig.defaults,%,$(wildcard boards/*/sdkconfig.defaults))))
@@ -73,8 +79,12 @@ esp_tools:
 	echo "==> ESP-IDF ready. Build with: make <board>"
 
 # Published image name: dist/<project>-<board>[-<VERSION>].bin (version appended
-# when VERSION is set, e.g. by the release workflow).
-$(BOARDS): IMG = $(PROJECT)-$@$(if $(VERSION),-$(VERSION))
+# when VERSION is set, e.g. by the release workflow). Sanitise the version for
+# the filename only — release tags may contain '/' (e.g. release/v1.2.3), which
+# would otherwise turn the cp target into a nested path. -DBRIDGE_VERSION still
+# receives the original VERSION, so the UI shows the tag verbatim.
+VERSION_FILENAME := $(subst /,-,$(VERSION))
+$(BOARDS): IMG = $(PROJECT)-$@$(if $(VERSION_FILENAME),-$(VERSION_FILENAME))
 
 $(BOARDS):
 	@echo "==> Building $(PROJECT) for board: $@"

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ esp_tools:
 	echo ""; \
 	echo "==> ESP-IDF ready. Build with: make <board>"
 
+# Published image name: dist/<project>-<board>[-<VERSION>].bin (version appended
+# when VERSION is set, e.g. by the release workflow).
+$(BOARDS): IMG = $(PROJECT)-$@$(if $(VERSION),-$(VERSION))
+
 $(BOARDS):
 	@echo "==> Building $(PROJECT) for board: $@"
 	@set -e; \
@@ -91,12 +95,12 @@ $(BOARDS):
 	fi; \
 	idf.py -DBOARD=$@ $(if $(VERSION),-DBRIDGE_VERSION=$(VERSION),) build; \
 	mkdir -p dist; \
-	cp build/$(PROJECT).bin dist/$(PROJECT)-$@.bin; \
+	cp build/$(PROJECT).bin dist/$(IMG).bin; \
 	echo "$@" > $(LAST_BOARD); \
 	echo ""; \
-	echo "==> Done. Flash/OTA image: dist/$(PROJECT)-$@.bin"; \
+	echo "==> Done. Flash/OTA image: dist/$(IMG).bin"; \
 	echo "    Serial flash:  idf.py -DBOARD=$@ -p <PORT> flash monitor"; \
-	echo "    OTA:           upload dist/$(PROJECT)-$@.bin from the web UI"
+	echo "    OTA:           upload dist/$(IMG).bin from the web UI"
 
 clean:
 	@if command -v idf.py >/dev/null 2>&1; then \

--- a/src/main/http_status.c
+++ b/src/main/http_status.c
@@ -5,6 +5,7 @@
 #include "ota.h"
 #include "ws_serial.h"
 #include "tls_cert.h"
+#include "version.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -22,11 +23,6 @@ extern const char icon_svg_end[]   asm("_binary_icon_svg_end");
 
 #define MAX_SCAN_APS  20
 
-// Shown in the web UI tagline. The release workflow stamps the tag in via
-// -DBRIDGE_VERSION=<tag>; this is the default for local/dev builds.
-#ifndef BRIDGE_VERSION
-#define BRIDGE_VERSION  "2026.6.0-alpha"
-#endif
 
 // Single-page UI. Status fields and the network list are filled by JS polling
 // /status and /scan, so the page itself is static and cacheable.

--- a/src/main/version.h
+++ b/src/main/version.h
@@ -1,0 +1,12 @@
+// Firmware version — shown in the web UI tagline and stamped into the build
+// artefact's filename.
+//
+// This default is the single source of truth: the Makefile reads BRIDGE_VERSION
+// from here so an unversioned `make <board>` still stamps and names the image
+// with it. The release workflow overrides it at build time with
+// -DBRIDGE_VERSION=<tag> (see CMakeLists.txt), hence the #ifndef guard.
+#pragma once
+
+#ifndef BRIDGE_VERSION
+#define BRIDGE_VERSION "2026.6.0-alpha"
+#endif


### PR DESCRIPTION
Names the build image `dist/betaflight-bridge-<board>-<version>.bin` when `VERSION` is set (the release workflow passes the tag), so release assets carry the version; local `make <board>` builds without `VERSION` keep the plain name. The CI artifact/release-attach steps now glob the per-board bin to match either form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build outputs now include versioned firmware filenames when a version is provided.
  * Release packaging now supports uploading and attaching multiple firmware binaries per board.

* **Bug Fixes**
  * Improved build and release handling so all matching board binaries are included automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->