### PR TITLE
Show client transport (TCP/ws/wss) on the status page

### DIFF
--- a/src/main/http_status.c
+++ b/src/main/http_status.c
@@ -5,6 +5,7 @@
 #include "ota.h"
 #include "ws_serial.h"
 #include "tls_cert.h"
+#include "bridge.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -68,7 +69,7 @@ static const char PAGE[] =
     "<div class=\"tag\">USB-host &#8596; WiFi bridge for Betaflight [" BRIDGE_VERSION "]</div>"
     "<div class=\"card\"><table>"
     "<tr><td class=\"k\">FC (USB VCP)</td><td id=\"usb\">…</td></tr>"
-    "<tr><td class=\"k\">Configurator (TCP)</td><td id=\"tcp\">…</td></tr>"
+    "<tr><td class=\"k\">Configurator</td><td id=\"tcp\">…</td></tr>"
     "<tr><td class=\"k\">WiFi network</td><td id=\"sta\">…</td></tr>"
     "<tr><td class=\"k\">Signal</td><td id=\"rssi\">…</td></tr>"
     "<tr><td class=\"k\">IP address</td><td id=\"ip\">…</td></tr>"
@@ -101,7 +102,9 @@ static const char PAGE[] =
     "function bars(r){return r>=-55?'\\u2588':r>=-67?'\\u2586':r>=-78?'\\u2584':'\\u2582'}"
     "function status(){fetch('/status').then(function(r){return r.json()}).then(function(s){"
     "$('usb').innerHTML=s.usb.up?('<span class=\\\"up\\\">connected</span> <code>'+s.usb.id+'</code>'):'<span class=\\\"down\\\">waiting…</span>';"
-    "$('tcp').innerHTML=s.tcp.up?'<span class=\\\"up\\\">connected</span> :'+s.tcp.port:'<span class=\\\"down\\\">none</span> :'+s.tcp.port;"
+    "if(s.tcp.up){var v=s.tcp.via,l=v=='tcp'?'TCP :'+s.tcp.port:v=='wss'?'WebSocket (wss)':'WebSocket (ws)';"
+    "$('tcp').innerHTML='<span class=\\\"up\\\">connected</span> <code>'+l+'</code>';}"
+    "else $('tcp').innerHTML='<span class=\\\"down\\\">none</span>';"
     "var w=s.wifi,h;"
     "if(w.state=='connected')h='<span class=\\\"up\\\">'+w.ssid+'</span>';"
     "else if(w.state=='connecting')h='<span class=\\\"warn\\\">connecting to '+w.ssid+'…</span>';"
@@ -202,7 +205,12 @@ static esp_err_t status_get(httpd_req_t *req)
 {
     uint16_t vid = 0, pid = 0;
     bool usb = usb_cdc_host_status(&vid, &pid);
-    bool tcp = tcp_server_client_connected();
+
+    // Which transport the connected Configurator arrived on (one at a time).
+    bridge_client_t owner = bridge_client_owner();
+    const char *via = owner == BRIDGE_CLIENT_TCP ? "tcp"
+                    : owner == BRIDGE_CLIENT_WS  ? (ws_serial_is_secure() ? "wss" : "ws")
+                    : "none";
 
     wifi_status_t w;
     wifi_sta_status(&w);
@@ -220,12 +228,12 @@ static esp_err_t status_get(httpd_req_t *req)
     char body[700];
     int n = snprintf(body, sizeof(body),
         "{\"usb\":{\"up\":%s,\"id\":\"%04x:%04x\"},"
-        "\"tcp\":{\"up\":%s,\"port\":%d},"
+        "\"tcp\":{\"up\":%s,\"via\":\"%s\",\"port\":%d},"
         "\"wifi\":{\"state\":\"%s\",\"ap\":%s,\"ssid\":\"%s\","
         "\"ip\":\"%s\",\"gw\":\"%s\",\"netmask\":\"%s\",\"rssi\":%d},"
         "\"ota\":{\"board\":\"%s\",\"slot\":\"%s\",\"valid\":%s}}",
         usb ? "true" : "false", vid, pid,
-        tcp ? "true" : "false", TCP_SERVER_PORT,
+        owner != BRIDGE_CLIENT_NONE ? "true" : "false", via, TCP_SERVER_PORT,
         state, w.ap_active ? "true" : "false", ssid_esc,
         w.ip, w.gw, w.netmask, w.rssi,
         ota_board_id(), slot, img_valid ? "true" : "false");
@@ -282,7 +290,7 @@ static esp_err_t wifi_post(httpd_req_t *req)
 // Attach the web UI + serial endpoints to a server (used for both the plain
 // HTTP and the TLS server, so the page and the ws/wss serial bridge are
 // reachable on either).
-static void register_routes(httpd_handle_t server)
+static void register_routes(httpd_handle_t server, bool secure)
 {
     const httpd_uri_t routes[] = {
         { .uri = "/",         .method = HTTP_GET,  .handler = root_get   },
@@ -294,8 +302,8 @@ static void register_routes(httpd_handle_t server)
     for (size_t i = 0; i < sizeof(routes) / sizeof(routes[0]); i++) {
         httpd_register_uri_handler(server, &routes[i]);
     }
-    ota_register(server);       // POST /update
-    ws_serial_register(server); // GET /serial (WebSocket)
+    ota_register(server);               // POST /update
+    ws_serial_register(server, secure); // GET /serial (WebSocket)
 }
 
 // Start the plain HTTP server on port 80 (web UI + ws:// serial).
@@ -312,7 +320,7 @@ static void start_http(void)
         ESP_LOGE(TAG, "failed to start HTTP server");
         return;
     }
-    register_routes(server);
+    register_routes(server, false);
     ESP_LOGI(TAG, "web UI on http://%s/ (port 80)", WIFI_AP_IP);
 }
 
@@ -342,7 +350,7 @@ static void start_https(void)
         ESP_LOGE(TAG, "failed to start HTTPS server");
         return;
     }
-    register_routes(server);
+    register_routes(server, true);
     ESP_LOGI(TAG, "web UI on https://%s/ (port 443); serial at wss://<ip>/serial", WIFI_AP_IP);
 }
 

--- a/src/main/ws_serial.c
+++ b/src/main/ws_serial.c
@@ -14,7 +14,13 @@ static const char *TAG = "ws";
 // fd (an fd is only meaningful within its httpd instance, so we keep both).
 static httpd_handle_t s_hd;
 static volatile int s_fd = -1;
+static volatile bool s_secure;   // current client arrived over TLS (wss)
 static TaskHandle_t s_tx_task;
+
+bool ws_serial_is_secure(void)
+{
+    return s_secure;
+}
 
 static void ws_drop(void)
 {
@@ -69,7 +75,8 @@ static esp_err_t ws_handler(httpd_req_t *req)
         bridge_try_claim(BRIDGE_CLIENT_WS);   // no-op if we already own it
         s_hd = req->handle;
         s_fd = new_fd;
-        ESP_LOGI(TAG, "client connected (fd %d)", new_fd);
+        s_secure = (req->user_ctx != NULL);   // set per-server at registration
+        ESP_LOGI(TAG, "client connected (fd %d, %s)", new_fd, s_secure ? "wss" : "ws");
         return ESP_OK;
     }
 
@@ -102,14 +109,17 @@ static esp_err_t ws_handler(httpd_req_t *req)
     return ret;
 }
 
-void ws_serial_register(httpd_handle_t server)
+void ws_serial_register(httpd_handle_t server, bool secure)
 {
-    static const httpd_uri_t uri = {
+    // user_ctx carries the secure flag so the handler can tell ws from wss.
+    const httpd_uri_t uri = {
         .uri = "/serial",
         .method = HTTP_GET,
         .handler = ws_handler,
         .is_websocket = true,
+        .handle_ws_control_frames = true,   // deliver CLOSE so we release the claim
         .supported_subprotocol = "wsSerial",
+        .user_ctx = secure ? (void *)1 : NULL,
     };
     httpd_register_uri_handler(server, &uri);
 

--- a/src/main/ws_serial.c
+++ b/src/main/ws_serial.c
@@ -17,15 +17,22 @@ static volatile int s_fd = -1;
 static volatile bool s_secure;   // current client arrived over TLS (wss)
 static TaskHandle_t s_tx_task;
 
+// Stable non-NULL marker for the TLS server's user_ctx (a real pointer, so no
+// int-to-pointer cast); its address just has to be distinct from NULL.
+static char s_secure_marker;
+
 bool ws_serial_is_secure(void)
 {
-    return s_secure;
+    // Only meaningful while a WS client owns the bridge; gate on ownership so a
+    // stale flag from a closed wss session can't read back as secure.
+    return bridge_client_owner() == BRIDGE_CLIENT_WS && s_secure;
 }
 
 static void ws_drop(void)
 {
     s_fd = -1;
     s_hd = NULL;
+    s_secure = false;
     bridge_release(BRIDGE_CLIENT_WS);
     bridge_reset();
 }
@@ -80,7 +87,12 @@ static esp_err_t ws_handler(httpd_req_t *req)
         return ESP_OK;
     }
 
-    // A frame from the Configurator. First call with len 0 gets the length.
+    // A frame from the Configurator. Frames may arrive from a superseded session
+    // (one we replaced via newest-wins but that hasn't finished closing) — those
+    // must not touch the promoted client's bridge, so gate on the active session.
+    bool active = (req->handle == s_hd && httpd_req_to_sockfd(req) == s_fd);
+
+    // First call with len 0 gets the length.
     httpd_ws_frame_t frame;
     memset(&frame, 0, sizeof(frame));
     frame.type = HTTPD_WS_TYPE_BINARY;
@@ -89,8 +101,10 @@ static esp_err_t ws_handler(httpd_req_t *req)
         return ret;
     }
     if (frame.type == HTTPD_WS_TYPE_CLOSE) {
-        ESP_LOGI(TAG, "client closed");
-        ws_drop();
+        if (active) {
+            ESP_LOGI(TAG, "client closed");
+            ws_drop();
+        }
         return ESP_OK;
     }
     if (frame.len) {
@@ -100,7 +114,7 @@ static esp_err_t ws_handler(httpd_req_t *req)
         }
         frame.payload = payload;
         ret = httpd_ws_recv_frame(req, &frame, frame.len);
-        if (ret == ESP_OK &&
+        if (ret == ESP_OK && active &&
             (frame.type == HTTPD_WS_TYPE_BINARY || frame.type == HTTPD_WS_TYPE_TEXT)) {
             bridge_net_to_usb_push(payload, frame.len);
         }
@@ -119,7 +133,7 @@ void ws_serial_register(httpd_handle_t server, bool secure)
         .is_websocket = true,
         .handle_ws_control_frames = true,   // deliver CLOSE so we release the claim
         .supported_subprotocol = "wsSerial",
-        .user_ctx = secure ? (void *)1 : NULL,
+        .user_ctx = secure ? &s_secure_marker : NULL,
     };
     httpd_register_uri_handler(server, &uri);
 

--- a/src/main/ws_serial.h
+++ b/src/main/ws_serial.h
@@ -4,8 +4,14 @@
 // raw-TCP server; only one Configurator client bridges at a time (see bridge.c).
 #pragma once
 
+#include <stdbool.h>
 #include "esp_http_server.h"
 
 // Register the /serial WebSocket handler on `server`. Call once per httpd
-// instance (HTTP and HTTPS). The FC->client pump task is spawned on first call.
-void ws_serial_register(httpd_handle_t server);
+// instance — pass secure=true for the TLS server so the status page can report
+// ws vs wss. The FC->client pump task is spawned on first call.
+void ws_serial_register(httpd_handle_t server, bool secure);
+
+// True when the currently-connected WebSocket client arrived over TLS (wss).
+// Only meaningful while a WS client owns the bridge.
+bool ws_serial_is_secure(void);


### PR DESCRIPTION
The status page's *Configurator* row now shows how the connected client arrived — `TCP`, `WebSocket (ws)` or `WebSocket (wss)` — sourced from `bridge_client_owner()` rather than only the raw-TCP server; `/status` gains a `tcp.via` field. Also enables WebSocket control-frame delivery so a clean client close releases the single-client claim (previously a closed WS session lingered and blocked the next TCP/WS client). Verified on hardware: none/ws/wss/tcp each report correctly and release on disconnect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The status page now shows which transport the Configurator is using: TCP, WebSocket (`ws`), or secure WebSocket (`wss`).
  * The `/status` response now includes clearer connection details so the UI can display the active transport.

* **Bug Fixes**
  * Connection status now more accurately reflects whether the Configurator is connected and how it connected.
  * Secure and non-secure WebSocket connections are now distinguished in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->