### PR TITLE
Make the HTTPS UI and wss serial reachable from a browser

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -21,6 +21,17 @@ CONFIG_ESP_MAIN_TASK_STACK_SIZE=10240
 # WebSocket support: the web UI serves a ws:// (and wss:// over TLS) serial
 # endpoint so browsers can bridge to the FC (browsers can't open raw TCP).
 CONFIG_HTTPD_WS_SUPPORT=y
+# Desktop browsers (Edge/Chrome) send a large header block — sec-ch-ua*,
+# sec-fetch-*, priority, long Accept/User-Agent — that overflows the 512-byte
+# default and trips "Header fields are too long". 2 KB clears a real request.
+CONFIG_HTTPD_MAX_REQ_HDR_LEN=2048
+
+# --- TLS ---
+# Browsers and curl send TLS 1.3-capable ClientHellos by default. A 1.2-only
+# mbedTLS server drops these instead of negotiating down, so the HTTPS UI and
+# wss:// serial endpoint reset the connection. Enable 1.3 server support so a
+# browser can reach https://<ip>/ and wss://<ip>/serial.
+CONFIG_MBEDTLS_SSL_PROTO_TLS1_3=y
 
 # --- WiFi ---
 CONFIG_ESP_WIFI_SOFTAP_SUPPORT=y


### PR DESCRIPTION
The HTTPS web UI and `wss://<ip>/serial` bridge were unreachable from a browser. Two fixes in `sdkconfig.defaults`:

- **TLS 1.3** — the server was built TLS 1.2-only, and mbedTLS 3.6 drops a TLS 1.3-capable ClientHello rather than negotiating down. Every modern browser (and curl) offers 1.3 by default, so they all saw `ERR_CONNECTION_RESET`. Enabling `CONFIG_MBEDTLS_SSL_PROTO_TLS1_3` lets the handshake complete.
- **Header buffer** — a desktop browser's request header block (`sec-ch-ua*`, `sec-fetch-*`, `priority`, long `User-Agent`) overflows the 512-byte default and trips "Header fields are too long". Raised `CONFIG_HTTPD_MAX_REQ_HDR_LEN` to 2 KB.

Verified on an ESP32-S3 (esp32s3-wroom-freenove): TLS 1.3 and 1.2 handshakes both serve the page (HTTP 200), a full Edge navigation header block loads cleanly, and a `wss://` `/serial` MSP round-trip succeeds.
