### PR TITLE
Add esp32s3-touch-lcd-4b board with native LVGL touch UI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,12 +56,13 @@ jobs:
           path: ~/.espressif
           key: esp-tools-${{ runner.os }}-${{ steps.idf.outputs.sha }}-esp32s3
 
-      # Cache the component-manager downloads keyed on the dependency lock.
+      # Cache the component-manager downloads keyed on the manifest. Per-board:
+      # rule-gated dependencies resolve to different component sets per board.
       - name: Cache managed components
         uses: actions/cache@v4
         with:
           path: managed_components
-          key: managed-${{ runner.os }}-${{ hashFiles('src/main/idf_component.yml', 'dependencies.lock') }}
+          key: managed-${{ runner.os }}-${{ matrix.board }}-${{ hashFiles('src/main/idf_component.yml') }}
 
       - name: Install ESP-IDF tools
         run: ./esp-idf/install.sh esp32s3

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ sdkconfig.old
 
 # Component manager
 /managed_components/
-dependencies.lock
+dependencies.lock*
 
 # Editor / OS
 .vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,20 @@ set(SDKCONFIG_DEFAULTS
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
+# Per-board dependency lock: boards with a display pull in extra managed
+# components (rule-gated in src/main/idf_component.yml), so a shared lock file
+# would be rewritten on every board switch.
+idf_build_set_property(DEPENDENCIES_LOCK "${CMAKE_CURRENT_LIST_DIR}/dependencies.lock.${BOARD}")
+
 # Sources live under src/main rather than the default ./main.
 set(EXTRA_COMPONENT_DIRS "src")
 
 project(betaflight-bridge)
+
+# The Waveshare BSPs use memcpy without including <string.h>; force the
+# include rather than patching the fetched component.
+idf_build_get_property(_components BUILD_COMPONENTS)
+if("waveshare__esp32_s3_touch_lcd_4b" IN_LIST _components)
+    idf_component_get_property(_bsp_lib waveshare__esp32_s3_touch_lcd_4b COMPONENT_LIB)
+    target_compile_options(${_bsp_lib} PRIVATE "SHELL:-include string.h")
+endif()

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ on the shared top-level `sdkconfig.defaults`. The USB-host pins
 |-------|-------|-------|-----|-------------|
 | `esp32s3-zero` (default) | 4 MB | — | single (native) | NeoPixel (GPIO21) |
 | `esp32s3-wroom-freenove` | 8 MB | 8 MB octal | dual (native + UART) | WiFi LED (GPIO2) + NeoPixel (GPIO48) |
+| `esp32s3-touch-lcd-4b` | 16 MB | 8 MB octal | single (native) | 4" LCD touch UI |
 
 A board identity (`BOARD_NAME`) is baked into each image (`esp_app_desc.version`)
 and checked on OTA, so an image built for one board is refused on another (see
@@ -79,6 +80,24 @@ and checked on OTA, so an image built for one board is refused on another (see
   - **GPIO48** — on-board WS2812 NeoPixel, FC/OTG comms.
 - **Partitions:** 8 MB dual-OTA, ~3 MB per slot
   (`boards/esp32s3-wroom-freenove/partitions.csv`).
+
+### `esp32s3-touch-lcd-4b` — Waveshare ESP32-S3-Touch-LCD-4B
+
+- **MCU / memory:** ESP32-S3 N16R8 — 16 MB flash, 8 MB **octal** PSRAM
+  (holds the LCD framebuffer).
+- **Display:** 4.0" 480×480 IPS (ST7701, 16-bit parallel RGB565) with GT911
+  capacitive touch, driven by the Waveshare BSP + LVGL
+  (`CONFIG_BRIDGE_DISPLAY`). The screen shows the same status as the web page —
+  FC link, Configurator client, WiFi, IP — and offers on-screen WiFi
+  scan/join/forget with a touch keyboard.
+- **USB:** one USB-C, wired to the native ESP32-S3 USB (D- GPIO19 / D+ GPIO20),
+  shared between flashing/console and the USB-host bridge — **the serial
+  console drops out once host mode engages**. UART0 (TX GPIO43 / RX GPIO44) is
+  broken out on the header for a persistent log console. Power the board from
+  its DC terminal or battery input when the USB-C is hosting the FC.
+- **LEDs:** none used — status is on the LCD.
+- **Partitions:** 16 MB dual-OTA, 6 MB per slot
+  (`boards/esp32s3-touch-lcd-4b/partitions.csv`).
 
 ### Status LED behaviour
 

--- a/boards/esp32s3-touch-lcd-4b/board.h
+++ b/boards/esp32s3-touch-lcd-4b/board.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Waveshare ESP32-S3-Touch-LCD-4B (N16R8): 4.0" 480x480 ST7701 RGB panel with
+// GT911 touch, driven by the waveshare/esp32_s3_touch_lcd_4b BSP component
+// (enabled via CONFIG_BRIDGE_DISPLAY in this board's sdkconfig.defaults).
+//
+// The single USB-C carries the native ESP32-S3 USB (D- GPIO19 / D+ GPIO20),
+// shared between flashing/console (USB-Serial-JTAG) and the USB-host bridge —
+// the serial console drops out once host mode engages (same as esp32s3-zero).
+// UART0 (TX GPIO43 / RX GPIO44) is on the header for a persistent log console.
+//
+// No user LEDs: status is shown on the LCD.
+#pragma once
+
+#define BOARD_NAME "esp32s3-touch-lcd-4b"

--- a/boards/esp32s3-touch-lcd-4b/partitions.csv
+++ b/boards/esp32s3-touch-lcd-4b/partitions.csv
@@ -1,0 +1,7 @@
+# 16 MB flash: dual-OTA app slots (6 MB each), remainder free for future assets.
+# Name,     Type, SubType, Offset,   Size
+nvs,        data, nvs,     0x9000,   0x6000
+otadata,    data, ota,     0xf000,   0x2000
+phy_init,   data, phy,     0x11000,  0x1000
+ota_0,      app,  ota_0,   0x20000,  0x600000
+ota_1,      app,  ota_1,   0x620000, 0x600000

--- a/boards/esp32s3-touch-lcd-4b/sdkconfig.defaults
+++ b/boards/esp32s3-touch-lcd-4b/sdkconfig.defaults
@@ -1,0 +1,31 @@
+# Waveshare ESP32-S3-Touch-LCD-4B (ESP32-S3 N16R8)
+
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="16MB"
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="boards/esp32s3-touch-lcd-4b/partitions.csv"
+
+# 8 MB octal PSRAM — holds the 480x480 RGB framebuffer.
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_MODE_OCT=y
+CONFIG_SPIRAM_SPEED_80M=y
+CONFIG_SPIRAM_FETCH_INSTRUCTIONS=y
+CONFIG_SPIRAM_RODATA=y
+
+# Keep the RGB panel fed alongside WiFi traffic.
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
+CONFIG_ESP32S3_DATA_CACHE_LINE_64B=y
+
+# No USB-UART bridge on this board: console on the native USB-Serial-JTAG
+# (drops out once USB host mode engages), UART0 stays free on the header.
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+
+# Board identity baked into the image and checked on OTA.
+CONFIG_APP_PROJECT_VER_FROM_CONFIG=y
+CONFIG_APP_PROJECT_VER="esp32s3-touch-lcd-4b"
+
+# Native LVGL touch UI (pulls in the BSP + LVGL managed components).
+CONFIG_BRIDGE_DISPLAY=y
+CONFIG_LV_COLOR_DEPTH_16=y
+CONFIG_LV_FONT_MONTSERRAT_14=y
+CONFIG_LV_FONT_MONTSERRAT_16=y
+CONFIG_LV_FONT_MONTSERRAT_20=y

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -10,6 +10,7 @@ idf_component_register(
         "tls_cert.c"
         "ota.c"
         "leds.c"
+        "display.c"
     EMBED_TXTFILES
         "icon.svg"                              # favicon served at /icon.svg
     INCLUDE_DIRS
@@ -28,6 +29,7 @@ idf_component_register(
         app_update
         esp_app_format
         esp_driver_gpio
+        esp_driver_i2c
 )
 
 # The release workflow stamps the firmware version in with

--- a/src/main/Kconfig.projbuild
+++ b/src/main/Kconfig.projbuild
@@ -1,0 +1,13 @@
+menu "Betaflight bridge"
+
+    config BRIDGE_DISPLAY
+        bool "Native LVGL touch status display"
+        default n
+        help
+            Drive an on-board LCD with a native LVGL touch UI showing the
+            bridge status (FC link, Configurator client, WiFi, IP) and
+            offering WiFi scan/join. Enabled per-board via the board's
+            sdkconfig.defaults; pulls in the board BSP and LVGL managed
+            components, which are not fetched when disabled.
+
+endmenu

--- a/src/main/display.c
+++ b/src/main/display.c
@@ -1,0 +1,458 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "display.h"
+#include "sdkconfig.h"
+
+#if CONFIG_BRIDGE_DISPLAY
+
+#include <stdio.h>
+#include <string.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+#include "esp_log.h"
+
+#include "bsp/esp32_s3_touch_lcd_4b.h"
+#include "lvgl.h"
+
+#include "wifi.h"
+#include "usb_cdc_host.h"
+#include "tcp_server.h"
+#include "bridge.h"
+#include "ws_serial.h"
+#include "ota.h"
+#include "version.h"
+
+static const char *TAG = "display";
+
+// Palette lifted from the web UI (http_status.c PAGE css).
+#define COL_BG      0x0f1115
+#define COL_CARD    0x181b20
+#define COL_BORDER  0x262b32
+#define COL_TEXT    0xe6e8ea
+#define COL_KEY     0x8b9199
+#define COL_UP      0x46c66d
+#define COL_DOWN    0x6b7178
+#define COL_WARN    0xFFBB00
+#define COL_ACCENT  0xFFBB00
+#define COL_MONO    0x7fc7ff
+
+#define REFRESH_MS      500
+#define DISPLAY_MAX_APS 20
+
+// Status tab value labels, updated by the refresh timer.
+static lv_obj_t *s_val_fc;
+static lv_obj_t *s_val_cfg;
+static lv_obj_t *s_val_sta;
+static lv_obj_t *s_val_rssi;
+static lv_obj_t *s_val_ip;
+static lv_obj_t *s_val_url;
+static lv_obj_t *s_val_gw;
+static lv_obj_t *s_val_mask;
+static lv_obj_t *s_val_ap;
+static lv_obj_t *s_val_slot;
+
+// WiFi tab.
+static lv_obj_t *s_ap_list;
+static lv_obj_t *s_spinner;
+static lv_obj_t *s_modal;         // join dialog overlay (NULL when closed)
+
+static SemaphoreHandle_t s_scan_req;
+static wifi_scan_ap_t s_aps[DISPLAY_MAX_APS];
+static int s_ap_count;
+
+static void set_value(lv_obj_t *label, const char *text, uint32_t colour)
+{
+    if (strcmp(lv_label_get_text(label), text) != 0) {
+        lv_label_set_text(label, text);
+    }
+    lv_obj_set_style_text_color(label, lv_color_hex(colour), 0);
+}
+
+static void refresh_cb(lv_timer_t *timer)
+{
+    (void)timer;
+    char buf[64];
+
+    uint16_t vid = 0, pid = 0;
+    bool usb = usb_cdc_host_status(&vid, &pid);
+    if (usb) {
+        snprintf(buf, sizeof(buf), "connected %04x:%04x", vid, pid);
+        set_value(s_val_fc, buf, COL_UP);
+    } else {
+        set_value(s_val_fc, "waiting...", COL_DOWN);
+    }
+
+    bridge_client_t owner = bridge_client_owner();
+    if (owner == BRIDGE_CLIENT_TCP) {
+        snprintf(buf, sizeof(buf), "connected TCP :%d", TCP_SERVER_PORT);
+        set_value(s_val_cfg, buf, COL_UP);
+    } else if (owner == BRIDGE_CLIENT_WS) {
+        snprintf(buf, sizeof(buf), "connected WebSocket (%s)", ws_serial_is_secure() ? "wss" : "ws");
+        set_value(s_val_cfg, buf, COL_UP);
+    } else {
+        set_value(s_val_cfg, "none", COL_DOWN);
+    }
+
+    wifi_status_t w;
+    wifi_sta_status(&w);
+    if (w.state == WIFI_STA_CONNECTED) {
+        set_value(s_val_sta, w.ssid, COL_UP);
+    } else if (w.state == WIFI_STA_CONNECTING) {
+        snprintf(buf, sizeof(buf), "connecting to %s...", w.ssid);
+        set_value(s_val_sta, buf, COL_WARN);
+    } else if (w.state == WIFI_STA_FAILED) {
+        snprintf(buf, sizeof(buf), "failed: %s", w.ssid);
+        set_value(s_val_sta, buf, COL_WARN);
+    } else {
+        set_value(s_val_sta, "none", COL_DOWN);
+    }
+
+    if (w.state == WIFI_STA_CONNECTED && w.rssi) {
+        // Same quality thresholds as the web UI.
+        const char *q = w.rssi >= -60 ? "good" : w.rssi >= -72 ? "fair" : "weak";
+        snprintf(buf, sizeof(buf), "%s %d dBm", q, w.rssi);
+        set_value(s_val_rssi, buf, w.rssi >= -60 ? COL_UP : COL_WARN);
+    } else {
+        set_value(s_val_rssi, "-", COL_DOWN);
+    }
+
+    set_value(s_val_ip, w.ip[0] ? w.ip : "-", w.ip[0] ? COL_MONO : COL_DOWN);
+    if (w.ip[0]) {
+        snprintf(buf, sizeof(buf), "http://%s", w.ip);
+        set_value(s_val_url, buf, COL_MONO);
+    } else if (w.ap_active) {
+        set_value(s_val_url, "http://" WIFI_AP_IP, COL_MONO);
+    } else {
+        set_value(s_val_url, "-", COL_DOWN);
+    }
+    set_value(s_val_gw, w.gw[0] ? w.gw : "-", w.gw[0] ? COL_MONO : COL_DOWN);
+    set_value(s_val_mask, w.netmask[0] ? w.netmask : "-", w.netmask[0] ? COL_MONO : COL_DOWN);
+
+    if (w.ap_active) {
+        set_value(s_val_ap, "broadcasting (setup mode)", COL_WARN);
+    } else {
+        set_value(s_val_ap, "off", COL_DOWN);
+    }
+
+    char slot[16];
+    bool valid = true;
+    ota_running_info(slot, sizeof(slot), &valid);
+    snprintf(buf, sizeof(buf), "%s %s", slot, valid ? "valid" : "pending verify");
+    set_value(s_val_slot, buf, valid ? COL_UP : COL_WARN);
+}
+
+// ---------------------------------------------------------------- WiFi tab
+
+static void scan_busy(bool busy)
+{
+    if (busy) {
+        lv_obj_remove_flag(s_spinner, LV_OBJ_FLAG_HIDDEN);
+    } else {
+        lv_obj_add_flag(s_spinner, LV_OBJ_FLAG_HIDDEN);
+    }
+}
+
+static void modal_close(void)
+{
+    if (s_modal) {
+        lv_obj_delete(s_modal);
+        s_modal = NULL;
+    }
+}
+
+static void join_selected(lv_event_t *e)
+{
+    lv_obj_t *ta = lv_event_get_user_data(e);
+    const char *ssid = lv_obj_get_user_data(ta);
+    wifi_set_station(ssid, lv_textarea_get_text(ta));
+    modal_close();
+}
+
+static void modal_cancel(lv_event_t *e)
+{
+    (void)e;
+    modal_close();
+}
+
+// Full-screen password prompt for a secured network: SSID title, password
+// box, Join/Cancel, and a keyboard docked to the bottom half.
+static void modal_open(const wifi_scan_ap_t *ap)
+{
+    modal_close();
+
+    s_modal = lv_obj_create(lv_layer_top());
+    lv_obj_set_size(s_modal, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_color(s_modal, lv_color_hex(COL_BG), 0);
+    lv_obj_set_style_border_width(s_modal, 0, 0);
+    lv_obj_set_style_radius(s_modal, 0, 0);
+    lv_obj_set_style_pad_all(s_modal, 12, 0);
+    lv_obj_remove_flag(s_modal, LV_OBJ_FLAG_SCROLLABLE);
+
+    lv_obj_t *title = lv_label_create(s_modal);
+    lv_label_set_text_fmt(title, "Join %s", ap->ssid);
+    lv_label_set_long_mode(title, LV_LABEL_LONG_DOT);
+    lv_obj_set_width(title, LV_PCT(100));
+    lv_obj_set_style_text_color(title, lv_color_hex(COL_ACCENT), 0);
+    lv_obj_align(title, LV_ALIGN_TOP_LEFT, 0, 4);
+
+    lv_obj_t *ta = lv_textarea_create(s_modal);
+    lv_textarea_set_one_line(ta, true);
+    lv_textarea_set_password_mode(ta, true);
+    lv_textarea_set_placeholder_text(ta, "Password");
+    lv_obj_set_width(ta, LV_PCT(100));
+    lv_obj_align(ta, LV_ALIGN_TOP_LEFT, 0, 36);
+    // The SSID rides along on the textarea so the join callback has both.
+    static char ssid_buf[33];
+    strlcpy(ssid_buf, ap->ssid, sizeof(ssid_buf));
+    lv_obj_set_user_data(ta, ssid_buf);
+
+    lv_obj_t *join = lv_button_create(s_modal);
+    lv_obj_align(join, LV_ALIGN_TOP_LEFT, 0, 92);
+    lv_obj_set_style_bg_color(join, lv_color_hex(COL_ACCENT), 0);
+    lv_obj_t *jl = lv_label_create(join);
+    lv_label_set_text(jl, "Join");
+    lv_obj_set_style_text_color(jl, lv_color_hex(0x15140e), 0);
+    lv_obj_add_event_cb(join, join_selected, LV_EVENT_CLICKED, ta);
+
+    lv_obj_t *cancel = lv_button_create(s_modal);
+    lv_obj_align(cancel, LV_ALIGN_TOP_LEFT, 110, 92);
+    lv_obj_set_style_bg_color(cancel, lv_color_hex(0x222831), 0);
+    lv_obj_t *cl = lv_label_create(cancel);
+    lv_label_set_text(cl, "Cancel");
+    lv_obj_add_event_cb(cancel, modal_cancel, LV_EVENT_CLICKED, NULL);
+
+    lv_obj_t *kb = lv_keyboard_create(s_modal);
+    lv_keyboard_set_textarea(kb, ta);
+    lv_obj_set_size(kb, LV_PCT(100), LV_PCT(45));
+    lv_obj_align(kb, LV_ALIGN_BOTTOM_MID, 0, 0);
+    lv_obj_add_event_cb(kb, join_selected, LV_EVENT_READY, ta);   // keyboard tick
+    lv_obj_add_event_cb(kb, modal_cancel, LV_EVENT_CANCEL, NULL); // keyboard cross
+}
+
+static void ap_clicked(lv_event_t *e)
+{
+    int idx = (int)(intptr_t)lv_event_get_user_data(e);
+    if (idx < 0 || idx >= s_ap_count) {
+        return;
+    }
+    if (s_aps[idx].secure) {
+        modal_open(&s_aps[idx]);
+    } else {
+        wifi_set_station(s_aps[idx].ssid, "");
+    }
+}
+
+// Rebuild the AP list from s_aps. Caller holds the display lock.
+static void scan_list_rebuild(void)
+{
+    lv_obj_clean(s_ap_list);
+    if (s_ap_count == 0) {
+        lv_obj_t *none = lv_list_add_text(s_ap_list, "no networks found");
+        lv_obj_set_style_text_color(none, lv_color_hex(COL_DOWN), 0);
+        return;
+    }
+    for (int i = 0; i < s_ap_count; i++) {
+        char item[64];
+        snprintf(item, sizeof(item), "%s  %s%d dBm",
+                 s_aps[i].ssid, s_aps[i].secure ? LV_SYMBOL_EYE_CLOSE " " : "", s_aps[i].rssi);
+        lv_obj_t *btn = lv_list_add_button(s_ap_list, LV_SYMBOL_WIFI, item);
+        lv_obj_set_style_bg_color(btn, lv_color_hex(COL_CARD), 0);
+        lv_obj_set_style_text_color(btn, lv_color_hex(COL_TEXT), 0);
+        lv_obj_add_event_cb(btn, ap_clicked, LV_EVENT_CLICKED, (void *)(intptr_t)i);
+    }
+}
+
+// wifi_scan() blocks for seconds — run it off the LVGL task and repopulate
+// the list under the display lock. One automatic scan shortly after boot,
+// then one per Rescan press.
+static void scan_task(void *arg)
+{
+    (void)arg;
+    vTaskDelay(pdMS_TO_TICKS(2000));
+    for (;;) {
+        int n = wifi_scan(s_aps, DISPLAY_MAX_APS);
+        bsp_display_lock(0);
+        s_ap_count = n;
+        scan_list_rebuild();
+        scan_busy(false);
+        bsp_display_unlock();
+        xSemaphoreTake(s_scan_req, portMAX_DELAY);
+    }
+}
+
+static void rescan_clicked(lv_event_t *e)
+{
+    (void)e;
+    scan_busy(true);
+    xSemaphoreGive(s_scan_req);
+}
+
+static void forget_clicked(lv_event_t *e)
+{
+    (void)e;
+    wifi_set_station("", "");
+}
+
+// ------------------------------------------------------------- UI assembly
+
+static lv_obj_t *add_row(lv_obj_t *parent, const char *key)
+{
+    lv_obj_t *row = lv_obj_create(parent);
+    lv_obj_set_size(row, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(row, 0, 0);
+    lv_obj_set_style_pad_all(row, 0, 0);
+    lv_obj_set_style_pad_bottom(row, 8, 0);
+    lv_obj_remove_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+
+    lv_obj_t *k = lv_label_create(row);
+    lv_label_set_text(k, key);
+    lv_obj_set_width(k, LV_PCT(42));
+    lv_obj_set_style_text_color(k, lv_color_hex(COL_KEY), 0);
+    lv_obj_align(k, LV_ALIGN_TOP_LEFT, 0, 0);
+
+    lv_obj_t *v = lv_label_create(row);
+    lv_label_set_text(v, "...");
+    lv_label_set_long_mode(v, LV_LABEL_LONG_DOT);
+    lv_obj_set_width(v, LV_PCT(56));
+    lv_obj_set_style_text_color(v, lv_color_hex(COL_TEXT), 0);
+    lv_obj_align(v, LV_ALIGN_TOP_RIGHT, 0, 0);
+    return v;
+}
+
+static void build_status_tab(lv_obj_t *tab)
+{
+    lv_obj_set_flex_flow(tab, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_style_pad_all(tab, 14, 0);
+    lv_obj_set_style_pad_row(tab, 2, 0);
+
+    s_val_fc   = add_row(tab, "FC (USB VCP)");
+    s_val_cfg  = add_row(tab, "Configurator");
+    s_val_sta  = add_row(tab, "WiFi network");
+    s_val_rssi = add_row(tab, "Signal");
+    s_val_ip   = add_row(tab, "IP address");
+    s_val_url  = add_row(tab, "Web UI");
+    s_val_gw   = add_row(tab, "Gateway");
+    s_val_mask = add_row(tab, "Netmask");
+    s_val_ap   = add_row(tab, "Access point");
+    lv_obj_t *board = add_row(tab, "Board");
+    set_value(board, ota_board_id(), COL_MONO);
+    s_val_slot = add_row(tab, "Firmware slot");
+
+    lv_obj_t *ver = lv_label_create(tab);
+    lv_label_set_text(ver, "betaflight-bridge " BRIDGE_VERSION);
+    lv_obj_set_style_text_color(ver, lv_color_hex(COL_KEY), 0);
+
+    lv_timer_create(refresh_cb, REFRESH_MS, NULL);
+    refresh_cb(NULL);
+}
+
+static void build_wifi_tab(lv_obj_t *tab)
+{
+    lv_obj_set_style_pad_all(tab, 14, 0);
+
+    lv_obj_t *rescan = lv_button_create(tab);
+    lv_obj_align(rescan, LV_ALIGN_TOP_LEFT, 0, 0);
+    lv_obj_set_style_bg_color(rescan, lv_color_hex(COL_ACCENT), 0);
+    lv_obj_t *rl = lv_label_create(rescan);
+    lv_label_set_text(rl, LV_SYMBOL_REFRESH " Rescan");
+    lv_obj_set_style_text_color(rl, lv_color_hex(0x15140e), 0);
+    lv_obj_add_event_cb(rescan, rescan_clicked, LV_EVENT_CLICKED, NULL);
+
+    lv_obj_t *forget = lv_button_create(tab);
+    lv_obj_align(forget, LV_ALIGN_TOP_LEFT, 130, 0);
+    lv_obj_set_style_bg_color(forget, lv_color_hex(0x222831), 0);
+    lv_obj_t *fl = lv_label_create(forget);
+    lv_label_set_text(fl, LV_SYMBOL_TRASH " Forget");
+    lv_obj_add_event_cb(forget, forget_clicked, LV_EVENT_CLICKED, NULL);
+
+    s_spinner = lv_spinner_create(tab);
+    lv_obj_set_size(s_spinner, 32, 32);
+    lv_obj_align(s_spinner, LV_ALIGN_TOP_RIGHT, 0, 2);
+
+    s_ap_list = lv_list_create(tab);
+    lv_obj_set_size(s_ap_list, LV_PCT(100), LV_PCT(84));
+    lv_obj_align(s_ap_list, LV_ALIGN_BOTTOM_MID, 0, 0);
+    lv_obj_set_style_bg_color(s_ap_list, lv_color_hex(COL_CARD), 0);
+    lv_obj_set_style_border_color(s_ap_list, lv_color_hex(COL_BORDER), 0);
+    lv_obj_t *hint = lv_list_add_text(s_ap_list, "scanning...");
+    lv_obj_set_style_text_color(hint, lv_color_hex(COL_KEY), 0);
+}
+
+static void build_ui(void)
+{
+    lv_obj_t *screen = lv_screen_active();
+    lv_obj_set_style_bg_color(screen, lv_color_hex(COL_BG), 0);
+
+    lv_obj_t *tv = lv_tabview_create(screen);
+    lv_tabview_set_tab_bar_size(tv, 52);
+    lv_obj_set_style_bg_color(tv, lv_color_hex(COL_BG), 0);
+
+    lv_obj_t *bar = lv_tabview_get_tab_bar(tv);
+    lv_obj_set_style_bg_color(bar, lv_color_hex(COL_CARD), 0);
+    lv_obj_set_style_text_color(bar, lv_color_hex(COL_TEXT), 0);
+
+    lv_obj_t *tab_status = lv_tabview_add_tab(tv, "Status");
+    lv_obj_t *tab_wifi   = lv_tabview_add_tab(tv, "WiFi");
+    lv_obj_set_style_bg_color(tab_status, lv_color_hex(COL_BG), 0);
+    lv_obj_set_style_bg_color(tab_wifi, lv_color_hex(COL_BG), 0);
+
+    build_status_tab(tab_status);
+    build_wifi_tab(tab_wifi);
+}
+
+void display_start(void)
+{
+    ESP_LOGI(TAG, "DIAG: bsp_display_start()...");
+    vTaskDelay(pdMS_TO_TICKS(200));
+    if (bsp_display_start() == NULL) {
+        ESP_LOGE(TAG, "display init failed");
+        return;
+    }
+    ESP_LOGI(TAG, "DIAG: bsp up, building UI");
+    vTaskDelay(pdMS_TO_TICKS(200));
+
+    bsp_display_lock(0);
+    lv_theme_t *theme = lv_theme_default_init(lv_display_get_default(),
+                                              lv_color_hex(COL_ACCENT),
+                                              lv_color_hex(COL_CARD),
+                                              true, &lv_font_montserrat_16);
+    lv_display_set_theme(lv_display_get_default(), theme);
+    build_ui();
+    bsp_display_unlock();
+    ESP_LOGI(TAG, "DIAG: UI built");
+
+    s_scan_req = xSemaphoreCreateBinary();
+    xTaskCreate(scan_task, "wifi_scan", 4096, NULL, 3, NULL);
+
+    // Light the panel only after the first UI is in the framebuffer.
+    bsp_display_backlight_on();
+    ESP_LOGI(TAG, "display ready");
+}
+
+#else  // no display on this board
+
+void display_start(void) { }
+
+#endif

--- a/src/main/display.c
+++ b/src/main/display.c
@@ -285,15 +285,19 @@ static void scan_list_rebuild(void)
 
 // wifi_scan() blocks for seconds — run it off the LVGL task and repopulate
 // the list under the display lock. One automatic scan shortly after boot,
-// then one per Rescan press.
+// then one per Rescan press. Scans land in a staging buffer: s_aps is only
+// written under the display lock, where ap_clicked() also reads it (LVGL
+// event callbacks run under the same mutex).
 static void scan_task(void *arg)
 {
     (void)arg;
+    static wifi_scan_ap_t aps[DISPLAY_MAX_APS];
     vTaskDelay(pdMS_TO_TICKS(2000));
     for (;;) {
-        int n = wifi_scan(s_aps, DISPLAY_MAX_APS);
+        int n = wifi_scan(aps, DISPLAY_MAX_APS);
         bsp_display_lock(0);
         s_ap_count = n;
+        memcpy(s_aps, aps, sizeof(aps));
         scan_list_rebuild();
         scan_busy(false);
         bsp_display_unlock();
@@ -424,14 +428,10 @@ static void build_ui(void)
 
 void display_start(void)
 {
-    ESP_LOGI(TAG, "DIAG: bsp_display_start()...");
-    vTaskDelay(pdMS_TO_TICKS(200));
     if (bsp_display_start() == NULL) {
         ESP_LOGE(TAG, "display init failed");
         return;
     }
-    ESP_LOGI(TAG, "DIAG: bsp up, building UI");
-    vTaskDelay(pdMS_TO_TICKS(200));
 
     bsp_display_lock(0);
     lv_theme_t *theme = lv_theme_default_init(lv_display_get_default(),
@@ -441,10 +441,11 @@ void display_start(void)
     lv_display_set_theme(lv_display_get_default(), theme);
     build_ui();
     bsp_display_unlock();
-    ESP_LOGI(TAG, "DIAG: UI built");
 
     s_scan_req = xSemaphoreCreateBinary();
-    xTaskCreate(scan_task, "wifi_scan", 4096, NULL, 3, NULL);
+    configASSERT(s_scan_req);
+    BaseType_t ok = xTaskCreate(scan_task, "wifi_scan", 4096, NULL, 3, NULL);
+    configASSERT(ok == pdTRUE);
 
     // Light the panel only after the first UI is in the framebuffer.
     bsp_display_backlight_on();

--- a/src/main/display.h
+++ b/src/main/display.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Native LVGL touch UI for boards with an LCD (CONFIG_BRIDGE_DISPLAY):
+// mirrors the web status page and offers WiFi scan/join on screen.
+// A board without a display gets a no-op. Call once after the bridge, WiFi,
+// TCP and USB-host subsystems are started.
+#pragma once
+
+void display_start(void);

--- a/src/main/idf_component.yml
+++ b/src/main/idf_component.yml
@@ -5,5 +5,15 @@ dependencies:
   espressif/usb_host_cdc_acm: "^2.0.0"
   # WS2812 NeoPixel driver (RMT backend) for the status LED.
   espressif/led_strip: "^2.5.0"
+  # Board support (LCD panel + touch + LVGL glue) for boards with a display.
+  # Rule-gated: only fetched when the board enables CONFIG_BRIDGE_DISPLAY.
+  waveshare/esp32_s3_touch_lcd_4b:
+    version: "^2.0.0"
+    rules:
+      - if: "$CONFIG{BRIDGE_DISPLAY} == True"
+  lvgl/lvgl:
+    version: "^9.2.0"
+    rules:
+      - if: "$CONFIG{BRIDGE_DISPLAY} == True"
   idf:
     version: ">=5.0"

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -41,6 +41,7 @@
 #include "http_status.h"
 #include "ota.h"
 #include "leds.h"
+#include "display.h"
 
 static const char *TAG = "main";
 
@@ -59,7 +60,8 @@ void app_main(void)
     http_status_start();
     tcp_server_start();
     usb_cdc_host_start();
-    leds_start();   // WiFi + FC-comms status LEDs (board-defined)
+    leds_start();      // WiFi + FC-comms status LEDs (board-defined)
+    display_start();   // LCD touch status UI (board-defined)
 
     // Everything came up: if we just booted a freshly-OTA'd image, confirm it
     // so the bootloader keeps it instead of rolling back on the next reset.


### PR DESCRIPTION
Adds the Waveshare ESP32-S3-Touch-LCD-4B (N16R8, 4" 480x480 ST7701 RGB panel, GT911 touch) as a bridge board, with a native LVGL touch UI that mirrors the web status page — FC link, Configurator client, WiFi state/signal, addresses, board and firmware slot — and offers WiFi scan/join/forget with an on-screen keyboard, driven entirely by the existing `wifi`/`usb_cdc_host`/`bridge` status APIs.

- Display support is gated behind a new `BRIDGE_DISPLAY` Kconfig symbol; the Waveshare BSP and LVGL managed components are rule-gated in the manifest, so `esp32s3-zero` and `esp32s3-wroom-freenove` neither fetch nor compile them (verified: their builds pull only the original two components).
- Rule-gated deps resolve per board, so the dependency lock is now per-board (`DEPENDENCIES_LOCK`), and the CI managed-components cache key includes the board.
- The published Waveshare BSP is missing a `<string.h>` include; a forced include on that component works around it without patching fetched sources.
- Board quirks documented in the README: console is the native USB-Serial-JTAG (drops when USB host mode engages, UART0 on the header remains), and the board boots only from a physical power cycle, not esptool's post-flash reset.

Verified on hardware: UI renders and updates live, WiFi join from the on-screen keyboard persists, and an FC enumerates over the USB-C in host mode with the display running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new ESP32-S3 board with onboard LCD and touch input.
  * Introduced a native on-device status screen (bridge + Wi‑Fi), including Wi‑Fi scan, join, forget, and connection feedback.
* **Documentation**
  * Updated usage docs with the new board’s hardware details, display/touch behaviour, USB-host notes, and partition sizing guidance.
* **Chores**
  * Improved build caching and per-board dependency lock handling; relaxed lockfile ignore patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->