### PR TITLE
Add libusb to host prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ ESP-IDF is vendored as a submodule. After cloning this repo:
 ```sh
 # Host prerequisites (Debian/Ubuntu): ESP-IDF's installer needs a working
 # venv + pip to build its Python environment.
-sudo apt install git wget cmake ninja-build python3-venv python3-pip
+sudo apt install git wget cmake ninja-build python3-venv python3-pip libusb-1.0-0 libusb-1.0-0-dev
 
 # Fetch the pinned ESP-IDF submodule and install its toolchain.
 make esp_tools


### PR DESCRIPTION
ESP-IDF fails to run with the following error if `libusb` isn't present:

```bash
ERROR: tool openocd-esp32 version v0.12.0-esp32-20260424 is installed, but getting error: non-zero exit code (127) with message: /home/yaros/.espressif/tools/openocd-esp32/v0.12.0-esp32-20260424/openocd-esp32/bin/openocd: error while loading shared libraries: libusb-1.0.so.0: cannot open shared object file: No such file or directory

ERROR: Failed to check the tool while installed. Removing directory /home/yaros/.espressif/tools/openocd-esp32/v0.12.0-esp32-20260424
make: *** [Makefile:71: esp_tools] Error 1
```

This is very common on WSL installs, as they don't come with `libusb` bundled in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Debian/Ubuntu setup instructions to include the additional USB library dependencies required to build the ESP-IDF host toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->