### PR TITLE
Update websocket supprotocol to binary to match app

### DIFF
--- a/src/main/ws_serial.c
+++ b/src/main/ws_serial.c
@@ -153,7 +153,7 @@ void ws_serial_register(httpd_handle_t server, bool secure)
         .handler = ws_handler,
         .is_websocket = true,
         .handle_ws_control_frames = true,   // deliver CLOSE so we release the claim
-        .supported_subprotocol = "wsSerial",
+        .supported_subprotocol = "binary",
         .user_ctx = secure ? &s_secure_marker : NULL,
     };
     httpd_register_uri_handler(server, &uri);


### PR DESCRIPTION
### Issue
<img width="561" height="123" alt="image" src="https://github.com/user-attachments/assets/9f6eb733-3911-4eff-b3bc-825710e232e0" />

The Betaflight app does not support the websocket subprotocol `wsSerial` anymore. See https://github.com/betaflight/betaflight-configurator/commit/35a195ac050d126b48eddf5ccc302c3606759559#diff-586fea03da7d8e7d48a570dced1bd75ed6e3272976dca8b80f6e613465b442a5R82

### Fix

Changing the subprotocol in the file `wsSerial.c` to `binary` allows the websocket connection to establish again.

### Comments

I've only tested the connection from my browser to the fc. I haven't encountered any issues after applying the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the WebSocket serial endpoint to advertise the correct `binary` subprotocol, improving compatibility with supported clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->