### PR TITLE
Announce the bridge via mDNS and show TCP and wss connect details

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It is a transparent byte bridge — no MSP parsing happens on the ESP32.
 |------|------|
 | `src/main/main.c` | Startup: NVS, bridge, WiFi, TCP server, USB host |
 | `src/main/usb_cdc_host.c` | USB host + CDC-ACM; opens the FC VCP, pumps bytes |
-| `src/main/tcp_server.c` | TCP listener on 5761; one Configurator client at a time |
+| `src/main/tcp_server.c` | TCP listener on 5761; one client at a time, newest connection wins |
 | `src/main/ws_serial.c` | WebSocket serial endpoint (`/serial`) for browser clients — ws:// and wss:// |
 | `src/main/tls_cert.c` | Self-signed TLS cert generated on first boot, persisted in NVS |
 | `src/main/bridge_mdns.c` | mDNS responder: `betaflight-bridge-<mac>.local`, `_betaflight._tcp` service |
@@ -257,9 +257,9 @@ on the status page.
 
 - Known FC VCP USB IDs (ST / Artery / Geehy) are listed in `usb_cdc_host.c`;
   add new vendors there.
-- Single client at a time — one Configurator connection, shared across the TCP
-  and WebSocket transports (a new browser connection supersedes a stale one; a
-  raw-TCP client in progress is left alone).
+- Single client at a time — one connection, shared across the TCP and
+  WebSocket transports. The newest connection wins: connecting from another
+  device (or a browser reconnecting) drops the current client.
 - `TCP_NODELAY` is set and Nagle effectively disabled to keep MSP latency low.
 
 ## Licence

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It is a transparent byte bridge — no MSP parsing happens on the ESP32.
 | `src/main/tcp_server.c` | TCP listener on 5761; one Configurator client at a time |
 | `src/main/ws_serial.c` | WebSocket serial endpoint (`/serial`) for browser clients — ws:// and wss:// |
 | `src/main/tls_cert.c` | Self-signed TLS cert generated on first boot, persisted in NVS |
+| `src/main/bridge_mdns.c` | mDNS responder: `betaflight-bridge-<mac>.local`, `_betaflight._tcp` service |
 | `src/main/wifi.c` | Station-first WiFi: joins a stored network, SoftAP fallback, creds in NVS |
 | `src/main/http_status.c` | Web UI on 80 (HTTP) and 443 (HTTPS): status + scan/join + firmware upload + `/serial` |
 | `src/main/ota.c` | `POST /update` OTA handler; streams an uploaded .bin into the spare slot |
@@ -192,6 +193,21 @@ the SoftAP is not started** — reach the web UI and Configurator at the IP your
 router assigns (shown on the page). If that network is ever unreachable at boot,
 the SoftAP comes back up automatically so you can reconfigure. Use *Forget* on
 the page to clear the stored network and return to AP-only setup mode.
+
+### Discovery (mDNS)
+
+The bridge announces itself on the local network so the app (or any Bonjour /
+Avahi browser) can find it without knowing the IP:
+
+- hostname `betaflight-bridge-<mac6>.local` (last three bytes of the WiFi MAC,
+  unique per unit; shown on the status page)
+- service `_betaflight._tcp` on port 5761 with TXT records `tcp=5761`, `ws=80`,
+  `wss=443`, `path=/serial`, `board=<board>`, `version=<firmware>`
+- service `_http._tcp` on port 80 (the web UI)
+
+```
+avahi-browse -rt _betaflight._tcp
+```
 
 ### Connecting from a browser (WebSocket / WSS)
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Avahi browser) can find it without knowing the IP:
   `wss=443`, `path=/serial`, `board=<board>`, `version=<firmware>`
 - service `_http._tcp` on port 80 (the web UI)
 
-```
+```sh
 avahi-browse -rt _betaflight._tcp
 ```
 

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -11,6 +11,7 @@ idf_component_register(
         "ota.c"
         "leds.c"
         "display.c"
+        "bridge_mdns.c"
     EMBED_TXTFILES
         "icon.svg"                              # favicon served at /icon.svg
     INCLUDE_DIRS
@@ -30,6 +31,7 @@ idf_component_register(
         esp_app_format
         esp_driver_gpio
         esp_driver_i2c
+        espressif__mdns
 )
 
 # The release workflow stamps the firmware version in with

--- a/src/main/bridge.c
+++ b/src/main/bridge.c
@@ -22,7 +22,9 @@
 #include "bridge.h"
 
 #include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "freertos/stream_buffer.h"
+#include "freertos/semphr.h"
 
 // Sized for MSP traffic: frames are small but dumps (e.g. `diff all`, blackbox
 // config) can burst several KB. 8 KB each direction gives comfortable slack.
@@ -33,6 +35,10 @@
 
 static StreamBufferHandle_t s_usb_to_net;  // FC  -> Configurator
 static StreamBufferHandle_t s_net_to_usb;  // Configurator -> FC
+// One receiver at a time per buffer: a client-takeover reset must never run
+// concurrently with a pump task blocked in xStreamBufferReceive (that asserts).
+static SemaphoreHandle_t s_u2n_mux;   // guards receives from s_usb_to_net
+static SemaphoreHandle_t s_n2u_mux;   // guards receives from s_net_to_usb
 
 // Total bytes moved to/from the FC in either direction. Monotonic; sampled by
 // the LED indicator to detect traffic. Plain increments are fine — a missed
@@ -48,8 +54,12 @@ void bridge_init(void)
 {
     s_usb_to_net = xStreamBufferCreate(BRIDGE_BUF_SIZE, BRIDGE_TRIGGER);
     s_net_to_usb = xStreamBufferCreate(BRIDGE_BUF_SIZE, BRIDGE_TRIGGER);
+    s_u2n_mux = xSemaphoreCreateMutex();
+    s_n2u_mux = xSemaphoreCreateMutex();
     configASSERT(s_usb_to_net);
     configASSERT(s_net_to_usb);
+    configASSERT(s_u2n_mux);
+    configASSERT(s_n2u_mux);
 }
 
 // Arbitration for the single FC stream. The claim is a tiny spinlock-guarded
@@ -57,19 +67,14 @@ void bridge_init(void)
 static portMUX_TYPE s_owner_mux = portMUX_INITIALIZER_UNLOCKED;
 static bridge_client_t s_owner = BRIDGE_CLIENT_NONE;
 
-bool bridge_try_claim(bridge_client_t who)
+void bridge_claim(bridge_client_t who)
 {
-    bool ok = false;
+    // Newest client wins: take ownership unconditionally. The previous owner's
+    // teardown is gated on still owning, so it won't release this claim.
     taskENTER_CRITICAL(&s_owner_mux);
-    if (s_owner == BRIDGE_CLIENT_NONE) {
-        s_owner = who;
-        ok = true;
-    }
+    s_owner = who;
     taskEXIT_CRITICAL(&s_owner_mux);
-    if (ok) {
-        bridge_reset();   // fresh session: drop any stale MSP bytes
-    }
-    return ok;
+    bridge_reset();   // fresh session: drop any stale MSP bytes
 }
 
 void bridge_release(bridge_client_t who)
@@ -97,7 +102,10 @@ size_t bridge_usb_to_net_push(const uint8_t *data, size_t len)
 
 size_t bridge_usb_to_net_pop(uint8_t *out, size_t max_len, uint32_t timeout_ms)
 {
-    return xStreamBufferReceive(s_usb_to_net, out, max_len, pdMS_TO_TICKS(timeout_ms));
+    xSemaphoreTake(s_u2n_mux, portMAX_DELAY);
+    size_t n = xStreamBufferReceive(s_usb_to_net, out, max_len, pdMS_TO_TICKS(timeout_ms));
+    xSemaphoreGive(s_u2n_mux);
+    return n;
 }
 
 size_t bridge_net_to_usb_push(const uint8_t *data, size_t len)
@@ -109,15 +117,25 @@ size_t bridge_net_to_usb_push(const uint8_t *data, size_t len)
 
 size_t bridge_net_to_usb_pop(uint8_t *out, size_t max_len, uint32_t timeout_ms)
 {
-    return xStreamBufferReceive(s_net_to_usb, out, max_len, pdMS_TO_TICKS(timeout_ms));
+    xSemaphoreTake(s_n2u_mux, portMAX_DELAY);
+    size_t n = xStreamBufferReceive(s_net_to_usb, out, max_len, pdMS_TO_TICKS(timeout_ms));
+    xSemaphoreGive(s_n2u_mux);
+    return n;
+}
+
+// xStreamBufferReset() asserts if a task is blocked receiving on the buffer, so
+// drain under the same mutex the pump tasks use to read it.
+static void drain(StreamBufferHandle_t sb, SemaphoreHandle_t mux)
+{
+    uint8_t junk[64];
+    xSemaphoreTake(mux, portMAX_DELAY);
+    while (xStreamBufferReceive(sb, junk, sizeof(junk), 0) > 0) {
+    }
+    xSemaphoreGive(mux);
 }
 
 void bridge_reset(void)
 {
-    if (s_usb_to_net) {
-        xStreamBufferReset(s_usb_to_net);
-    }
-    if (s_net_to_usb) {
-        xStreamBufferReset(s_net_to_usb);
-    }
+    drain(s_usb_to_net, s_u2n_mux);
+    drain(s_net_to_usb, s_n2u_mux);
 }

--- a/src/main/bridge.h
+++ b/src/main/bridge.h
@@ -32,19 +32,20 @@
 // push/pop helpers below.
 void bridge_init(void);
 
-// Which transport currently owns the FC byte stream. Only one Configurator
-// client may bridge at a time, shared across the raw-TCP server and the
-// WebSocket endpoint (the stream buffers are single-consumer).
+// Which transport currently owns the FC byte stream. Only one client bridges
+// at a time, shared across the raw-TCP server and the WebSocket endpoint (the
+// stream buffers are single-consumer). A new connection on either transport
+// takes over: the transports kick the current owner and bridge_claim().
 typedef enum {
     BRIDGE_CLIENT_NONE = 0,
     BRIDGE_CLIENT_TCP,
     BRIDGE_CLIENT_WS,
 } bridge_client_t;
 
-// Atomically claim the FC stream for `who`. Returns true on success, or false if
-// another client already owns it. On success the buffers are reset and the
-// caller must bridge_release() when the client goes away.
-bool bridge_try_claim(bridge_client_t who);
+// Claim the FC stream for `who`, taking it over from any current owner (newest
+// client wins). The buffers are reset; the caller must bridge_release() when its
+// client goes away, but only while it still owns (see bridge_client_owner()).
+void bridge_claim(bridge_client_t who);
 
 // Release a claim previously taken by `who` (no-op if `who` is not the owner).
 void bridge_release(bridge_client_t who);

--- a/src/main/bridge_mdns.c
+++ b/src/main/bridge_mdns.c
@@ -24,6 +24,7 @@
 #include "ota.h"
 #include "version.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 
 #include "esp_mac.h"
@@ -32,10 +33,16 @@
 
 static const char *TAG = "mdns";
 
-static char s_hostname[32];
+static char s_hostname[MDNS_NAME_BUF_LEN];
+static bool s_started;
 
 const char *bridge_mdns_hostname(void)
 {
+    // The responder renames itself (e.g. "-2") if the name collides on the
+    // network, so report what it is actually using.
+    if (s_started) {
+        mdns_hostname_get(s_hostname);
+    }
     return s_hostname;
 }
 
@@ -50,9 +57,6 @@ void bridge_mdns_start(void)
         ESP_LOGE(TAG, "mdns_init failed: %s", esp_err_to_name(err));
         return;
     }
-    mdns_hostname_set(s_hostname);
-    mdns_instance_name_set(s_hostname);
-
     char tcp_port[8];
     snprintf(tcp_port, sizeof(tcp_port), "%d", TCP_SERVER_PORT);
     mdns_txt_item_t txt[] = {
@@ -63,8 +67,23 @@ void bridge_mdns_start(void)
         { "board",   ota_board_id() },
         { "version", BRIDGE_VERSION },
     };
-    mdns_service_add(NULL, "_betaflight", "_tcp", TCP_SERVER_PORT, txt, sizeof(txt) / sizeof(txt[0]));
-    mdns_service_add(NULL, "_http", "_tcp", 80, NULL, 0);
 
+    err = mdns_hostname_set(s_hostname);
+    if (err == ESP_OK) {
+        err = mdns_instance_name_set(s_hostname);
+    }
+    if (err == ESP_OK) {
+        err = mdns_service_add(NULL, "_betaflight", "_tcp", TCP_SERVER_PORT, txt, sizeof(txt) / sizeof(txt[0]));
+    }
+    if (err == ESP_OK) {
+        err = mdns_service_add(NULL, "_http", "_tcp", 80, NULL, 0);
+    }
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "registration failed: %s", esp_err_to_name(err));
+        mdns_free();
+        return;
+    }
+
+    s_started = true;
     ESP_LOGI(TAG, "announcing %s.local (_betaflight._tcp:%d)", s_hostname, TCP_SERVER_PORT);
 }

--- a/src/main/bridge_mdns.c
+++ b/src/main/bridge_mdns.c
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "bridge_mdns.h"
+#include "tcp_server.h"
+#include "ota.h"
+#include "version.h"
+
+#include <stdio.h>
+
+#include "esp_mac.h"
+#include "esp_log.h"
+#include "mdns.h"
+
+static const char *TAG = "mdns";
+
+static char s_hostname[32];
+
+const char *bridge_mdns_hostname(void)
+{
+    return s_hostname;
+}
+
+void bridge_mdns_start(void)
+{
+    uint8_t mac[6] = {0};
+    esp_read_mac(mac, ESP_MAC_WIFI_STA);
+    snprintf(s_hostname, sizeof(s_hostname), "betaflight-bridge-%02x%02x%02x", mac[3], mac[4], mac[5]);
+
+    esp_err_t err = mdns_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "mdns_init failed: %s", esp_err_to_name(err));
+        return;
+    }
+    mdns_hostname_set(s_hostname);
+    mdns_instance_name_set(s_hostname);
+
+    char tcp_port[8];
+    snprintf(tcp_port, sizeof(tcp_port), "%d", TCP_SERVER_PORT);
+    mdns_txt_item_t txt[] = {
+        { "tcp",     tcp_port },
+        { "ws",      "80" },
+        { "wss",     "443" },
+        { "path",    "/serial" },
+        { "board",   ota_board_id() },
+        { "version", BRIDGE_VERSION },
+    };
+    mdns_service_add(NULL, "_betaflight", "_tcp", TCP_SERVER_PORT, txt, sizeof(txt) / sizeof(txt[0]));
+    mdns_service_add(NULL, "_http", "_tcp", 80, NULL, 0);
+
+    ESP_LOGI(TAG, "announcing %s.local (_betaflight._tcp:%d)", s_hostname, TCP_SERVER_PORT);
+}

--- a/src/main/bridge_mdns.h
+++ b/src/main/bridge_mdns.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// mDNS announcement so the app can find the bridge on the LAN without knowing
+// its IP. Hostname is betaflight-bridge-<mac6>.local (unique per unit). Services:
+//   _betaflight._tcp  port 5761, TXT: tcp, ws, wss, path, board, version
+//   _http._tcp        port 80 (generic Bonjour/Avahi browsers)
+#pragma once
+
+// Start the responder. Call once after the WiFi netifs exist; it follows
+// whichever interface (STA or SoftAP) is up.
+void bridge_mdns_start(void);
+
+// Advertised hostname without the ".local" suffix, e.g. "betaflight-bridge-a1b2c3".
+const char *bridge_mdns_hostname(void);

--- a/src/main/http_status.c
+++ b/src/main/http_status.c
@@ -28,6 +28,7 @@
 #include "tls_cert.h"
 #include "bridge.h"
 #include "version.h"
+#include "bridge_mdns.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -88,11 +89,13 @@ static const char PAGE[] =
     "<div class=\"tag\">USB-host &#8596; WiFi bridge for Betaflight [" BRIDGE_VERSION "]</div>"
     "<div class=\"card\"><table>"
     "<tr><td class=\"k\">FC (USB VCP)</td><td id=\"usb\">…</td></tr>"
-    "<tr><td class=\"k\">Configurator</td><td id=\"tcp\">…</td></tr>"
+    "<tr><td class=\"k\">Client</td><td id=\"tcp\">…</td></tr>"
     "<tr><td class=\"k\">WiFi network</td><td id=\"sta\">…</td></tr>"
     "<tr><td class=\"k\">Signal</td><td id=\"rssi\">…</td></tr>"
     "<tr><td class=\"k\">IP address</td><td id=\"ip\">…</td></tr>"
-    "<tr><td class=\"k\">Browser connect</td><td id=\"url\">…</td></tr>"
+    "<tr><td class=\"k\">mDNS name</td><td id=\"host\">…</td></tr>"
+    "<tr><td class=\"k\">TCP connect</td><td id=\"tcpurl\">…</td></tr>"
+    "<tr><td class=\"k\">Browser connect (wss)</td><td id=\"url\">…</td></tr>"
     "<tr><td class=\"k\">Gateway</td><td id=\"gw\">…</td></tr>"
     "<tr><td class=\"k\">Netmask</td><td id=\"mask\">…</td></tr>"
     "<tr><td class=\"k\">Access point</td><td id=\"ap\">…</td></tr>"
@@ -136,6 +139,8 @@ static const char PAGE[] =
     "$('rssi').innerHTML='<code>'+bars(rs)+'</code> '+q+' <code>'+rs+' dBm</code>';"
     "}else $('rssi').innerHTML='<span class=\\\"down\\\">—</span>';"
     "$('ip').innerHTML=w.ip?'<code>'+w.ip+'</code>':'<span class=\\\"down\\\">—</span>';"
+    "$('host').innerHTML=w.host?'<code>'+w.host+'</code>':'<span class=\\\"down\\\">—</span>';"
+    "$('tcpurl').innerHTML=w.ip?'<code>tcp://'+w.ip+':'+s.tcp.port+'</code>':'<span class=\\\"down\\\">—</span>';"
     "$('url').innerHTML=w.ip?'<code>wss://'+w.ip+'/serial</code>':'<span class=\\\"down\\\">—</span>';"
     "$('gw').innerHTML=w.gw?'<code>'+w.gw+'</code>':'<span class=\\\"down\\\">—</span>';"
     "$('mask').innerHTML=w.netmask?'<code>'+w.netmask+'</code>':'<span class=\\\"down\\\">—</span>';"
@@ -244,16 +249,16 @@ static esp_err_t status_get(httpd_req_t *req)
     bool img_valid = true;
     ota_running_info(slot, sizeof(slot), &img_valid);
 
-    char body[700];
+    char body[800];
     int n = snprintf(body, sizeof(body),
         "{\"usb\":{\"up\":%s,\"id\":\"%04x:%04x\"},"
         "\"tcp\":{\"up\":%s,\"via\":\"%s\",\"port\":%d},"
-        "\"wifi\":{\"state\":\"%s\",\"ap\":%s,\"ssid\":\"%s\","
+        "\"wifi\":{\"state\":\"%s\",\"ap\":%s,\"ssid\":\"%s\",\"host\":\"%s.local\","
         "\"ip\":\"%s\",\"gw\":\"%s\",\"netmask\":\"%s\",\"rssi\":%d},"
         "\"ota\":{\"board\":\"%s\",\"slot\":\"%s\",\"valid\":%s}}",
         usb ? "true" : "false", vid, pid,
         owner != BRIDGE_CLIENT_NONE ? "true" : "false", via, TCP_SERVER_PORT,
-        state, w.ap_active ? "true" : "false", ssid_esc,
+        state, w.ap_active ? "true" : "false", ssid_esc, bridge_mdns_hostname(),
         w.ip, w.gw, w.netmask, w.rssi,
         ota_board_id(), slot, img_valid ? "true" : "false");
 

--- a/src/main/http_status.c
+++ b/src/main/http_status.c
@@ -37,6 +37,9 @@
 #include "esp_http_server.h"
 #include "esp_https_server.h"
 #include "esp_log.h"
+#include "esp_system.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 static const char *TAG = "http";
 
@@ -101,7 +104,10 @@ static const char PAGE[] =
     "<tr><td class=\"k\">Access point</td><td id=\"ap\">…</td></tr>"
     "<tr><td class=\"k\">Board</td><td id=\"board\">…</td></tr>"
     "<tr><td class=\"k\">Firmware slot</td><td id=\"slot\">…</td></tr>"
-    "</table></div>"
+    "</table>"
+    "<div class=\"btns\"><button class=\"sec\" onclick=\"kick()\">Disconnect client</button>"
+    "<button class=\"sec\" onclick=\"reboot()\">Restart bridge</button></div>"
+    "<div class=\"msg\" id=\"ctl\"></div></div>"
     "<div class=\"card\"><h2>Join a WiFi network</h2>"
     "<label for=\"ssid\">Network</label>"
     "<select id=\"ssid\" onchange=\"pick()\"><option value=\"\">— scanning… —</option>"
@@ -164,6 +170,11 @@ static const char PAGE[] =
     "function forget(){$('msg').textContent='Clearing…';"
     "fetch('/wifi',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'ssid='})"
     ".then(function(){$('msg').textContent='Stored network cleared.'})}"
+    "function kick(){$('ctl').textContent='Disconnecting…';"
+    "fetch('/disconnect',{method:'POST'}).then(function(r){$('ctl').textContent=r.ok?'Client disconnected.':'Request failed.'})"
+    ".catch(function(){$('ctl').textContent='Request failed.'})}"
+    "function reboot(){if(!confirm('Restart the bridge?'))return;$('ctl').textContent='Restarting — back in ~10s.';"
+    "fetch('/reboot',{method:'POST'}).catch(function(){});setTimeout(function(){location.reload()},12000)}"
     "function upload(){var f=$('fw').files[0];if(!f){$('up').textContent='Pick a .bin file.';return}"
     "var x=new XMLHttpRequest();x.open('POST','/update');"
     "x.upload.onprogress=function(e){if(e.lengthComputable)$('up').textContent='Uploading '+Math.round(e.loaded/e.total*100)+'%…'};"
@@ -311,6 +322,30 @@ static esp_err_t wifi_post(httpd_req_t *req)
     return httpd_resp_sendstr(req, "{\"ok\":true}");
 }
 
+static esp_err_t disconnect_post(httpd_req_t *req)
+{
+    ESP_LOGI(TAG, "web request to disconnect client");
+    tcp_server_kick();
+    ws_serial_kick();
+    httpd_resp_set_type(req, "application/json");
+    return httpd_resp_sendstr(req, "{\"ok\":true}");
+}
+
+static void restart_task(void *arg)
+{
+    vTaskDelay(pdMS_TO_TICKS(300));   // let the response leave the socket
+    esp_restart();
+}
+
+static esp_err_t reboot_post(httpd_req_t *req)
+{
+    ESP_LOGI(TAG, "web request to restart");
+    httpd_resp_set_type(req, "application/json");
+    esp_err_t err = httpd_resp_sendstr(req, "{\"ok\":true}");
+    xTaskCreate(restart_task, "restart", 2048, NULL, 5, NULL);
+    return err;
+}
+
 // Attach the web UI + serial endpoints to a server (used for both the plain
 // HTTP and the TLS server, so the page and the ws/wss serial bridge are
 // reachable on either).
@@ -322,6 +357,8 @@ static void register_routes(httpd_handle_t server, bool secure)
         { .uri = "/status",   .method = HTTP_GET,  .handler = status_get },
         { .uri = "/scan",     .method = HTTP_GET,  .handler = scan_get   },
         { .uri = "/wifi",     .method = HTTP_POST, .handler = wifi_post  },
+        { .uri = "/disconnect", .method = HTTP_POST, .handler = disconnect_post },
+        { .uri = "/reboot",   .method = HTTP_POST, .handler = reboot_post },
     };
     for (size_t i = 0; i < sizeof(routes) / sizeof(routes[0]); i++) {
         httpd_register_uri_handler(server, &routes[i]);

--- a/src/main/http_status.h
+++ b/src/main/http_status.h
@@ -25,6 +25,8 @@
 //   GET  /status  JSON snapshot of USB, TCP and WiFi state
 //   GET  /scan    JSON list of nearby networks
 //   POST /wifi    form-encoded ssid/pass; saves and joins live (empty = forget)
+//   POST /disconnect  drop the connected client (TCP or WebSocket)
+//   POST /reboot  restart the bridge
 #pragma once
 
 // Start the HTTP server. Call after WiFi is up.

--- a/src/main/idf_component.yml
+++ b/src/main/idf_component.yml
@@ -5,6 +5,8 @@ dependencies:
   espressif/usb_host_cdc_acm: "^2.0.0"
   # WS2812 NeoPixel driver (RMT backend) for the status LED.
   espressif/led_strip: "^2.5.0"
+  # mDNS responder so the app can discover the bridge on the LAN.
+  espressif/mdns: "^1.4.0"
   # Board support (LCD panel + touch + LVGL glue) for boards with a display.
   # Rule-gated: only fetched when the board enables CONFIG_BRIDGE_DISPLAY.
   waveshare/esp32_s3_touch_lcd_4b:

--- a/src/main/tcp_server.c
+++ b/src/main/tcp_server.c
@@ -20,8 +20,10 @@
  */
 
 #include "tcp_server.h"
+#include "ws_serial.h"
 #include "bridge.h"
 
+#include <stdint.h>
 #include <string.h>
 #include <errno.h>
 
@@ -48,79 +50,63 @@ void tcp_server_kick(void)
     int fd = s_client;
     if (fd >= 0) {
         ESP_LOGI(TAG, "kicking client");
+        // shutdown() makes the fd readable in the accept task's select(), which
+        // then reaps it via close_client(). (A bare recv() would not wake, but
+        // select() does.)
         shutdown(fd, SHUT_RDWR);
     }
 }
 
-// Drains FC->Configurator bytes from the bridge and writes them to the client.
-static void tcp_tx_task(void *arg)
+// Send FC->Configurator bytes to the connected TCP client. Called by the single
+// net TX pump (ws_serial.c) only while the TCP client owns the bridge.
+void tcp_server_send(const uint8_t *data, size_t len)
 {
-    static uint8_t buf[1024];
-    while (1) {
-        int fd = s_client;
-        if (fd < 0) {
-            // No TCP client: don't drain, or we'd steal bytes destined for a
-            // WebSocket client that owns the stream instead.
-            vTaskDelay(pdMS_TO_TICKS(20));
-            continue;
-        }
-        size_t n = bridge_usb_to_net_pop(buf, sizeof(buf), 100);
-        if (n == 0) {
-            continue;
-        }
-        size_t off = 0;
-        while (off < n) {
-            int sent = send(fd, buf + off, n - off, 0);
-            if (sent < 0) {
-                if (errno == EAGAIN || errno == EWOULDBLOCK) {
-                    vTaskDelay(pdMS_TO_TICKS(2));
-                    continue;
-                }
-                ESP_LOGW(TAG, "send failed: errno %d", errno);
-                break;  // accept task will notice on its next recv
+    int fd = s_client;
+    if (fd < 0) {
+        return;
+    }
+    size_t off = 0;
+    while (off < len) {
+        int sent = send(fd, data + off, len - off, 0);
+        if (sent < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                vTaskDelay(pdMS_TO_TICKS(2));
+                continue;
             }
-            off += sent;
+            ESP_LOGW(TAG, "send failed: errno %d", errno);
+            return;   // accept task's select() notices the dead socket
         }
+        off += sent;
     }
 }
 
-static void serve_client(int fd)
+// Drop the served client, if any, releasing the bridge only while we still own
+// it (a WebSocket client may have taken over). Closes the socket.
+static void close_client(void)
 {
-    // One Configurator at a time, shared with the WebSocket endpoint.
-    if (!bridge_try_claim(BRIDGE_CLIENT_TCP)) {
-        ESP_LOGW(TAG, "client rejected: bridge busy");
-        close(fd);
+    int fd = s_client;
+    if (fd < 0) {
         return;
     }
-
-    // Low latency: push MSP frames out immediately rather than coalescing.
-    int one = 1;
-    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
-
-    s_client = fd;   // bridge_try_claim already reset the buffers
-    ESP_LOGI(TAG, "client connected");
-
-    uint8_t buf[1024];
-    while (1) {
-        int n = recv(fd, buf, sizeof(buf), 0);
-        if (n > 0) {
-            bridge_net_to_usb_push(buf, n);
-        } else if (n == 0) {
-            ESP_LOGI(TAG, "client closed");
-            break;
-        } else {
-            if (errno == EINTR) {
-                continue;
-            }
-            ESP_LOGW(TAG, "recv failed: errno %d", errno);
-            break;
-        }
-    }
-
     s_client = -1;
-    bridge_release(BRIDGE_CLIENT_TCP);
-    bridge_reset();
+    if (bridge_client_owner() == BRIDGE_CLIENT_TCP) {
+        bridge_release(BRIDGE_CLIENT_TCP);
+    }
     close(fd);
+}
+
+// Adopt a freshly accepted client as the single served connection, taking the
+// bridge over from any current owner (newest connection wins).
+static void adopt_client(int fd)
+{
+    int one = 1;
+    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));  // low MSP latency
+    s_client = fd;
+    // Take the bridge over from any owner (incl. a WebSocket client). Its own
+    // task notices the ownership change and drops it; we do not reach across
+    // transports here, which would risk blocking the httpd worker.
+    bridge_claim(BRIDGE_CLIENT_TCP);
+    ESP_LOGI(TAG, "client connected");
 }
 
 static void tcp_accept_task(void *arg)
@@ -155,20 +141,75 @@ static void tcp_accept_task(void *arg)
 
     ESP_LOGI(TAG, "listening on port %d", TCP_SERVER_PORT);
 
+    // Single task, single served client. select() watches the listener and the
+    // client together: a pending connection wakes us to accept it (dropping the
+    // current client — newest wins), and the client fd wakes us on data or on
+    // close/shutdown (so a kick via tcp_server_kick() is noticed immediately).
+    // Keeping one task and closing the old socket on takeover avoids leaking
+    // sockets into lwIP's small descriptor table.
+    static uint8_t buf[1024];
     while (1) {
-        struct sockaddr_in src;
-        socklen_t slen = sizeof(src);
-        int fd = accept(listen_fd, (struct sockaddr *)&src, &slen);
-        if (fd < 0) {
-            ESP_LOGW(TAG, "accept() failed: errno %d", errno);
+        fd_set rfds;
+        FD_ZERO(&rfds);
+        FD_SET(listen_fd, &rfds);
+        int maxfd = listen_fd;
+        int client = s_client;
+        if (client >= 0) {
+            FD_SET(client, &rfds);
+            if (client > maxfd) {
+                maxfd = client;
+            }
+        }
+
+        // 200 ms timeout so we poll ownership even when idle: a WebSocket
+        // client may have taken the bridge, in which case we drop ours.
+        struct timeval tv = { .tv_sec = 0, .tv_usec = 200000 };
+        if (select(maxfd + 1, &rfds, NULL, NULL, &tv) < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            ESP_LOGW(TAG, "select() failed: errno %d", errno);
+            vTaskDelay(pdMS_TO_TICKS(20));
             continue;
         }
-        serve_client(fd);  // blocks until this client disconnects
+
+        // Superseded by a client on the other transport: drop ours.
+        if (client >= 0 && bridge_client_owner() != BRIDGE_CLIENT_TCP) {
+            ESP_LOGI(TAG, "superseded; dropping client");
+            close_client();
+            continue;
+        }
+
+        // Client activity: data to forward, or a closed/kicked socket to reap.
+        if (client >= 0 && FD_ISSET(client, &rfds)) {
+            int n = recv(client, buf, sizeof(buf), 0);
+            if (n > 0) {
+                bridge_net_to_usb_push(buf, n);
+            } else {
+                ESP_LOGI(TAG, "client %s", n == 0 ? "closed" : "gone");
+                close_client();
+            }
+        }
+
+        // A new connection is pending: accept it and let it take over.
+        if (FD_ISSET(listen_fd, &rfds)) {
+            struct sockaddr_in src;
+            socklen_t slen = sizeof(src);
+            int fd = accept(listen_fd, (struct sockaddr *)&src, &slen);
+            if (fd < 0) {
+                ESP_LOGW(TAG, "accept() failed: errno %d", errno);
+                continue;
+            }
+            if (s_client >= 0) {
+                ESP_LOGI(TAG, "new client; dropping current TCP client");
+                close_client();
+            }
+            adopt_client(fd);   // claims the bridge; a WS owner drops itself
+        }
     }
 }
 
 void tcp_server_start(void)
 {
-    xTaskCreate(tcp_tx_task, "tcp_tx", 4096, NULL, 6, NULL);
     xTaskCreate(tcp_accept_task, "tcp_accept", 4096, NULL, 5, NULL);
 }

--- a/src/main/tcp_server.c
+++ b/src/main/tcp_server.c
@@ -43,6 +43,15 @@ bool tcp_server_client_connected(void)
     return s_client >= 0;
 }
 
+void tcp_server_kick(void)
+{
+    int fd = s_client;
+    if (fd >= 0) {
+        ESP_LOGI(TAG, "kicking client");
+        shutdown(fd, SHUT_RDWR);
+    }
+}
+
 // Drains FC->Configurator bytes from the bridge and writes them to the client.
 static void tcp_tx_task(void *arg)
 {

--- a/src/main/tcp_server.h
+++ b/src/main/tcp_server.h
@@ -35,3 +35,7 @@ void tcp_server_start(void);
 
 // True while a Configurator client is connected.
 bool tcp_server_client_connected(void);
+
+// Drop the connected client, if any. The serve loop notices and releases the
+// bridge; no-op when nobody is connected.
+void tcp_server_kick(void);

--- a/src/main/tcp_server.h
+++ b/src/main/tcp_server.h
@@ -20,10 +20,13 @@
  */
 
 // TCP server that Betaflight Configurator connects to (TCP transport, MSP over a
-// raw stream). Accepts a single client at a time and bridges it to the FC VCP.
+// raw stream). One client at a time is bridged to the FC VCP; a new connection
+// takes over from the current one (TCP or WebSocket).
 #pragma once
 
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 // Default listen port. Matches Betaflight SITL / Configurator's TCP default.
 #ifndef TCP_SERVER_PORT
@@ -39,3 +42,7 @@ bool tcp_server_client_connected(void);
 // Drop the connected client, if any. The serve loop notices and releases the
 // bridge; no-op when nobody is connected.
 void tcp_server_kick(void);
+
+// Send FC bytes to the connected TCP client (no-op if none). Called by the
+// single net TX pump while a TCP client owns the bridge.
+void tcp_server_send(const uint8_t *data, size_t len);

--- a/src/main/wifi.c
+++ b/src/main/wifi.c
@@ -283,6 +283,10 @@ void wifi_start(void)
 
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+    // Modem sleep (the default) drops multicast between DTIM beacons, so mDNS
+    // queries go unanswered for seconds at a time and browsers expire the
+    // bridge. The board is USB powered; keep the radio awake.
+    ESP_ERROR_CHECK(esp_wifi_set_ps(WIFI_PS_NONE));
 
     // Both interfaces exist up front: the STA must be present for scanning and
     // live joins, and the AP netif must exist so the fallback can raise it. The

--- a/src/main/wifi.c
+++ b/src/main/wifi.c
@@ -20,6 +20,7 @@
  */
 
 #include "wifi.h"
+#include "bridge_mdns.h"
 
 #include <string.h>
 #include <stdlib.h>
@@ -288,6 +289,7 @@ void wifi_start(void)
     // AP only *broadcasts* once the mode includes it (see ensure_ap()).
     s_ap_netif  = esp_netif_create_default_wifi_ap();
     s_sta_netif = esp_netif_create_default_wifi_sta();
+    bridge_mdns_start();
 
     char ssid[33] = {0};
     char pass[65] = {0};

--- a/src/main/ws_serial.c
+++ b/src/main/ws_serial.c
@@ -21,6 +21,7 @@
 
 #include "ws_serial.h"
 #include "bridge.h"
+#include "tcp_server.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -63,8 +64,11 @@ static void ws_drop(void)
     s_fd = -1;
     s_hd = NULL;
     s_secure = false;
-    bridge_release(BRIDGE_CLIENT_WS);
-    bridge_reset();
+    // Only release if we still own it: a newer client may have taken over, in
+    // which case the bridge is theirs and this is just a late socket close.
+    if (bridge_client_owner() == BRIDGE_CLIENT_WS) {
+        bridge_release(BRIDGE_CLIENT_WS);
+    }
 }
 
 // Per-session marker so httpd tells us when the socket goes away for any reason
@@ -85,30 +89,54 @@ static void ws_session_closed(void *ctx)
     free(sess);
 }
 
-// FC -> WebSocket client. Drains the bridge and pushes binary frames to the
-// active client; a send failure means the client has gone, so we let go.
-static void ws_tx_task(void *arg)
+// Set to the fd we have already asked httpd to close, so we trigger it once.
+static int s_closing_fd = -1;
+
+// Send FC bytes to the connected WebSocket client. Only called by the pump while
+// a WS client owns the bridge, so s_hd/s_fd are valid.
+static void ws_send(const uint8_t *data, size_t len)
+{
+    httpd_ws_frame_t frame = {
+        .final = true,
+        .type = HTTPD_WS_TYPE_BINARY,
+        .payload = (uint8_t *)data,
+        .len = len,
+    };
+    if (httpd_ws_send_frame_async(s_hd, s_fd, &frame) != ESP_OK) {
+        ESP_LOGW(TAG, "send failed; dropping client");
+        ws_drop();
+    }
+}
+
+// Single FC -> Configurator pump. It is the only consumer of the FC->net buffer,
+// so there is never a second reader to race with; it routes each frame to the
+// client that currently owns the bridge (or discards it when nobody does). A WS
+// client that has just been superseded is closed here so the newest connection
+// wins.
+static void net_tx_task(void *arg)
 {
     static uint8_t buf[1024];
     while (1) {
-        int fd = s_fd;
-        if (fd < 0 || bridge_client_owner() != BRIDGE_CLIENT_WS) {
-            vTaskDelay(pdMS_TO_TICKS(20));
-            continue;
+        // Close a superseded WS client (owner moved to TCP) once.
+        if (s_fd >= 0 && bridge_client_owner() != BRIDGE_CLIENT_WS && s_fd != s_closing_fd) {
+            ESP_LOGI(TAG, "superseded; dropping client (fd %d)", s_fd);
+            s_closing_fd = s_fd;
+            httpd_sess_trigger_close(s_hd, s_fd);
         }
+
         size_t n = bridge_usb_to_net_pop(buf, sizeof(buf), 100);
         if (n == 0) {
             continue;
         }
-        httpd_ws_frame_t frame = {
-            .final = true,
-            .type = HTTPD_WS_TYPE_BINARY,
-            .payload = buf,
-            .len = n,
-        };
-        if (httpd_ws_send_frame_async(s_hd, fd, &frame) != ESP_OK) {
-            ESP_LOGW(TAG, "send failed; dropping client");
-            ws_drop();
+        switch (bridge_client_owner()) {
+        case BRIDGE_CLIENT_TCP:
+            tcp_server_send(buf, n);
+            break;
+        case BRIDGE_CLIENT_WS:
+            ws_send(buf, n);
+            break;
+        default:
+            break;   // no owner: discard
         }
     }
 }
@@ -116,13 +144,9 @@ static void ws_tx_task(void *arg)
 static esp_err_t ws_handler(httpd_req_t *req)
 {
     if (req->method == HTTP_GET) {
-        // WebSocket handshake. A raw-TCP client takes priority; otherwise the
-        // newest WebSocket client wins (so a browser reconnect isn't locked out
-        // by a stale, half-closed session).
-        if (bridge_client_owner() == BRIDGE_CLIENT_TCP) {
-            ESP_LOGW(TAG, "rejected: raw-TCP client active");
-            return ESP_FAIL;
-        }
+        // WebSocket handshake. The newest client wins, whatever transport the
+        // current one is on (so a reconnect isn't locked out by a stale,
+        // half-closed session).
         int new_fd = httpd_req_to_sockfd(req);
         ws_session_t *sess = malloc(sizeof(*sess));
         if (!sess) {
@@ -132,12 +156,22 @@ static esp_err_t ws_handler(httpd_req_t *req)
         sess->fd = new_fd;
         req->sess_ctx = sess;
         req->free_ctx = ws_session_closed;
-        if (s_fd >= 0 && !(s_hd == req->handle && s_fd == new_fd)) {
-            httpd_sess_trigger_close(s_hd, s_fd);   // boot the previous client
-        }
-        bridge_try_claim(BRIDGE_CLIENT_WS);   // no-op if we already own it
+        // Newest client wins. Adopt this session first so the predecessor's
+        // teardown (gated on the active fd/owner) can't tear us down, then drop
+        // the previous owner on whichever transport it was.
+        httpd_handle_t prev_hd = s_hd;
+        int prev_fd = s_fd;
         s_hd = req->handle;
         s_fd = new_fd;
+        s_closing_fd = -1;
+        if (prev_fd >= 0 && !(prev_hd == req->handle && prev_fd == new_fd)) {
+            ESP_LOGI(TAG, "new client; dropping current WebSocket client");
+            httpd_sess_trigger_close(prev_hd, prev_fd);
+        }
+        // Take the bridge over from any owner (incl. a TCP client). Its own task
+        // notices the ownership change and drops it; we do not reach across
+        // transports here, which would risk blocking the httpd worker.
+        bridge_claim(BRIDGE_CLIENT_WS);
         s_secure = (req->user_ctx != NULL);   // set per-server at registration
         ESP_LOGI(TAG, "client connected (fd %d, %s)", new_fd, s_secure ? "wss" : "ws");
         return ESP_OK;
@@ -194,6 +228,6 @@ void ws_serial_register(httpd_handle_t server, bool secure)
     httpd_register_uri_handler(server, &uri);
 
     if (!s_tx_task) {
-        xTaskCreate(ws_tx_task, "ws_tx", 4096, NULL, 6, &s_tx_task);
+        xTaskCreate(net_tx_task, "net_tx", 4096, NULL, 6, &s_tx_task);
     }
 }

--- a/src/main/ws_serial.c
+++ b/src/main/ws_serial.c
@@ -115,19 +115,20 @@ static esp_err_t ws_handler(httpd_req_t *req)
             return ESP_FAIL;
         }
         int new_fd = httpd_req_to_sockfd(req);
+        ws_session_t *sess = malloc(sizeof(*sess));
+        if (!sess) {
+            return ESP_ERR_NO_MEM;
+        }
+        sess->hd = req->handle;
+        sess->fd = new_fd;
+        req->sess_ctx = sess;
+        req->free_ctx = ws_session_closed;
         if (s_fd >= 0 && !(s_hd == req->handle && s_fd == new_fd)) {
             httpd_sess_trigger_close(s_hd, s_fd);   // boot the previous client
         }
         bridge_try_claim(BRIDGE_CLIENT_WS);   // no-op if we already own it
         s_hd = req->handle;
         s_fd = new_fd;
-        ws_session_t *sess = malloc(sizeof(*sess));
-        if (sess) {
-            sess->hd = req->handle;
-            sess->fd = new_fd;
-            req->sess_ctx = sess;
-            req->free_ctx = ws_session_closed;
-        }
         s_secure = (req->user_ctx != NULL);   // set per-server at registration
         ESP_LOGI(TAG, "client connected (fd %d, %s)", new_fd, s_secure ? "wss" : "ws");
         return ESP_OK;

--- a/src/main/ws_serial.c
+++ b/src/main/ws_serial.c
@@ -49,6 +49,15 @@ bool ws_serial_is_secure(void)
     return bridge_client_owner() == BRIDGE_CLIENT_WS && s_secure;
 }
 
+void ws_serial_kick(void)
+{
+    int fd = s_fd;
+    if (fd >= 0 && s_hd) {
+        ESP_LOGI(TAG, "kicking client (fd %d)", fd);
+        httpd_sess_trigger_close(s_hd, fd);
+    }
+}
+
 static void ws_drop(void)
 {
     s_fd = -1;

--- a/src/main/ws_serial.c
+++ b/src/main/ws_serial.c
@@ -58,6 +58,24 @@ static void ws_drop(void)
     bridge_reset();
 }
 
+// Per-session marker so httpd tells us when the socket goes away for any reason
+// (abrupt disconnect, TLS teardown), not only on a CLOSE frame. Without this an
+// unclean drop leaves a dead client owning the bridge and locks out raw TCP.
+typedef struct {
+    httpd_handle_t hd;
+    int fd;
+} ws_session_t;
+
+static void ws_session_closed(void *ctx)
+{
+    ws_session_t *sess = ctx;
+    if (sess->hd == s_hd && sess->fd == s_fd) {
+        ESP_LOGI(TAG, "client gone (fd %d)", sess->fd);
+        ws_drop();
+    }
+    free(sess);
+}
+
 // FC -> WebSocket client. Drains the bridge and pushes binary frames to the
 // active client; a send failure means the client has gone, so we let go.
 static void ws_tx_task(void *arg)
@@ -103,6 +121,13 @@ static esp_err_t ws_handler(httpd_req_t *req)
         bridge_try_claim(BRIDGE_CLIENT_WS);   // no-op if we already own it
         s_hd = req->handle;
         s_fd = new_fd;
+        ws_session_t *sess = malloc(sizeof(*sess));
+        if (sess) {
+            sess->hd = req->handle;
+            sess->fd = new_fd;
+            req->sess_ctx = sess;
+            req->free_ctx = ws_session_closed;
+        }
         s_secure = (req->user_ctx != NULL);   // set per-server at registration
         ESP_LOGI(TAG, "client connected (fd %d, %s)", new_fd, s_secure ? "wss" : "ws");
         return ESP_OK;
@@ -153,7 +178,7 @@ void ws_serial_register(httpd_handle_t server, bool secure)
         .handler = ws_handler,
         .is_websocket = true,
         .handle_ws_control_frames = true,   // deliver CLOSE so we release the claim
-        .supported_subprotocol = "wsSerial",
+        .supported_subprotocol = "binary",   // what the app requests; must be echoed or the browser aborts
         .user_ctx = secure ? &s_secure_marker : NULL,
     };
     httpd_register_uri_handler(server, &uri);

--- a/src/main/ws_serial.h
+++ b/src/main/ws_serial.h
@@ -22,7 +22,8 @@
 // WebSocket serial endpoint. Browsers can't open raw TCP, so this exposes the
 // FC byte stream over a WebSocket at /serial — reachable as ws:// on the plain
 // HTTP server and wss:// on the TLS server. Transparent binary bridge, like the
-// raw-TCP server; only one Configurator client bridges at a time (see bridge.c).
+// raw-TCP server; one client bridges at a time and the newest connection wins
+// (see bridge.c).
 #pragma once
 
 #include <stdbool.h>

--- a/src/main/ws_serial.h
+++ b/src/main/ws_serial.h
@@ -33,6 +33,10 @@
 // ws vs wss. The FC->client pump task is spawned on first call.
 void ws_serial_register(httpd_handle_t server, bool secure);
 
+// Close the connected WebSocket client, if any; the session close callback
+// releases the bridge.
+void ws_serial_kick(void);
+
 // True when the currently-connected WebSocket client arrived over TLS (wss).
 // Only meaningful while a WS client owns the bridge.
 bool ws_serial_is_secure(void);


### PR DESCRIPTION
Adds an mDNS responder (`espressif/mdns`) so the app can discover the bridge without knowing its IP. Hostname is `betaflight-bridge-<mac6>.local`, unique per unit. Advertises `_betaflight._tcp` on 5761 with TXT records `tcp`, `ws`, `wss`, `path`, `board` and `version`, plus `_http._tcp` for the web UI.

The status page now shows the mDNS name, the raw TCP address and the wss URL as separate rows, and `/status` gains `wifi.host`. Two buttons join the status card: disconnect the current client (TCP or WebSocket, `POST /disconnect`) and restart the bridge (`POST /reboot`). A new connection now takes the bridge over from the current client (newest wins) rather than being rejected, so switching devices just works; served over a single select()-based accept task with one FC->client pump that routes by owner.

WiFi modem sleep is disabled (`WIFI_PS_NONE`). With the default power save the radio missed multicast for 6 to 20 s at a time, so mDNS queries went unanswered in bursts: first discovery took up to 15 s and a long lived browser whose 80/85/90/95 % refresh queries all fell in a gap expired the bridge after its 120 s record TTL. Captured on the wire before and after: answers now arrive within 200 ms of every query and a 5 minute browse holds the entry with no removal. The board is USB powered so there is nothing to save.

Two WebSocket fixes found while testing against the app: the `/serial` endpoint now echoes the `binary` subprotocol the app requests (browsers abort the handshake otherwise), and an unclean WS disconnect releases the bridge claim via the session free callback rather than only on a CLOSE frame, so a dropped browser no longer locks out raw TCP.

Tested on esp32s3-wroom-freenove via OTA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic network discovery via mDNS for TCP, WebSocket, secure WebSocket and HTTP services.
  * Displays the device hostname and connection URLs in the web interface.
  * Added controls to disconnect the active client and restart the bridge.
  * New connections now take over from the current client.

* **Bug Fixes**
  * Improved cleanup when WebSocket sessions disconnect unexpectedly.
  * Reports the actual hostname after network naming conflicts.

* **Documentation**
  * Added mDNS discovery details, advertised services and connection information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->