### PR TITLE
feat(build): publish a complete flashable factory image per board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ help:
 	@echo ""
 	@echo "Usage:"
 	@echo "  make esp_tools build/update the ESP-IDF submodule and toolchain"
-	@echo "  make <board>   build the flash/OTA image for <board>"
+	@echo "  make <board>   build the OTA and factory images for <board>"
 	@echo "  make clean     remove build artefacts"
 	@echo "  make help      show this message"
 	@echo ""
@@ -56,7 +56,9 @@ help:
 	  fi; \
 	done
 	@echo ""
-	@echo "The build image is written to dist/$(PROJECT)-<board>.bin"
+	@echo "Each build writes two images to dist/:"
+	@echo "  $(PROJECT)-<board>.bin          app only, for OTA (0x20000)"
+	@echo "  $(PROJECT)-<board>-factory.bin  whole flash, for a first flash (0x0)"
 
 # Bare board names (machine-readable, one per line) for scripting/CI.
 list:
@@ -86,6 +88,11 @@ esp_tools:
 VERSION_FILENAME := $(subst /,-,$(VERSION))
 $(BOARDS): IMG = $(PROJECT)-$@$(if $(VERSION_FILENAME),-$(VERSION_FILENAME))
 
+# Each build also emits <IMG>-factory.bin: bootloader + partition table + blank
+# otadata/NVS + app merged into one blob flashed at 0x0, so a stock board can be
+# flashed from a browser with no toolchain. Offsets and flash mode/freq/size come
+# from the build's own flash args file, so they always match the board.
+
 $(BOARDS):
 	@echo "==> Building $(PROJECT) for board: $@"
 	@set -e; \
@@ -106,10 +113,18 @@ $(BOARDS):
 	idf.py -DBOARD=$@ $(if $(VERSION),-DBRIDGE_VERSION=$(VERSION),) build; \
 	mkdir -p dist; \
 	cp build/$(PROJECT).bin dist/$(IMG).bin; \
+	args=$$(ls build/flash_args build/flash_project_args 2>/dev/null | head -1); \
+	if [ -z "$$args" ]; then echo "no flash args in build/; cannot merge"; exit 1; fi; \
+	( cd build && esptool.py --chip $(IDF_TARGET) merge_bin \
+	    -o ../dist/$(IMG)-factory.bin @$${args#build/} ); \
 	echo "$@" > $(LAST_BOARD); \
 	echo ""; \
-	echo "==> Done. Flash/OTA image: dist/$(IMG).bin"; \
+	echo "==> Done."; \
+	echo "    OTA image:     dist/$(IMG).bin (app only, 0x20000)"; \
+	echo "    Factory image: dist/$(IMG)-factory.bin (whole flash, 0x0)"; \
+	echo ""; \
 	echo "    Serial flash:  idf.py -DBOARD=$@ -p <PORT> flash monitor"; \
+	echo "    Browser flash: esptool-js, factory image at offset 0x0"; \
 	echo "    OTA:           upload dist/$(IMG).bin from the web UI"
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,9 @@ help:
 	  fi; \
 	done
 	@echo ""
-	@echo "Each build writes two images to dist/:"
-	@echo "  $(PROJECT)-<board>.bin          app only, for OTA (0x20000)"
-	@echo "  $(PROJECT)-<board>-factory.bin  whole flash, for a first flash (0x0)"
+	@echo "Each build writes two images to dist/ (-<version> from VERSION):"
+	@echo "  $(PROJECT)-<board>[-<version>].bin          app only, for OTA (0x20000)"
+	@echo "  $(PROJECT)-<board>[-<version>]-factory.bin  whole flash, first flash (0x0)"
 
 # Bare board names (machine-readable, one per line) for scripting/CI.
 list:

--- a/README.md
+++ b/README.md
@@ -158,9 +158,17 @@ make esp32s3-wroom-freenove # build the image for a board
 make clean                  # remove build/, dist/ and sdkconfig
 ```
 
-Each build writes `dist/betaflight-bridge-<board>.bin` — the image used for both
-serial flashing and OTA. Switching boards triggers a clean reconfigure, so you
-don't need to delete `sdkconfig` by hand.
+Each build writes two images to `dist/`. Switching boards triggers a clean
+reconfigure, so you don't need to delete `sdkconfig` by hand.
+
+| File | Offset | Use |
+|------|--------|-----|
+| `betaflight-bridge-<board>.bin` | `0x20000` | OTA update from the web UI |
+| `betaflight-bridge-<board>-factory.bin` | `0x0` | first flash of a stock board |
+
+The factory image is the app plus the bootloader, partition table and a blank
+otadata/NVS, merged into one blob — everything a bare board needs. The plain
+image is the app alone, which is what the OTA endpoint expects.
 
 To flash and monitor over serial, use `idf.py` directly:
 
@@ -171,6 +179,40 @@ idf.py -DBOARD=esp32s3-wroom-freenove -p /dev/ttyACM0 flash monitor
 On the dual-USB Freenove, flash/monitor over the CH343 UART port — it stays
 connected even after the firmware switches the native USB into host mode. On the
 single-port ZERO the console drops once host mode engages.
+
+## First flash from a browser
+
+The factory image needs no toolchain and no clone — download
+`betaflight-bridge-<board>-factory.bin` for your board from the
+[releases page](../../releases) and flash it at offset `0x0`:
+
+1. Open <https://espressif.github.io/esptool-js/> in Chrome or Edge (Web Serial
+   is not available in Firefox or Safari).
+2. **Connect**, and pick the board's port.
+3. Set the offset to `0x0`, choose the factory `.bin`, then **Program**.
+
+Or, with esptool installed locally:
+
+```sh
+esptool.py --chip esp32s3 write_flash 0x0 betaflight-bridge-<board>-factory.bin
+```
+
+Afterwards the board is updated over WiFi — see [Updating](#updating-ota).
+
+**Pick the image matching your board.** All three boards are ESP32-S3, so a
+flasher cannot tell them apart, but the flash sizes (4/8/16 MB) and partition
+tables are not interchangeable. A mismatched image may fail to boot — hold
+**BOOT** while resetting to get back into download mode and re-flash.
+
+**A factory flash wipes stored settings.** The saved WiFi credentials and the
+self-signed TLS certificate both live in NVS, which the merged image blanks. The
+board comes back up in SoftAP mode as if new, and the browser certificate
+exception has to be accepted again (see [Connecting](#connecting)).
+
+To get a port the flasher can see, hold **BOOT** while resetting the board. On
+the single-port ZERO and Touch-LCD-4B this is required once the firmware has
+switched the native USB into host mode; on the Freenove use the CH343 UART port,
+which is always available.
 
 ## Connecting
 
@@ -234,10 +276,12 @@ the bridge's IP changes or the certificate is cleared (e.g. an NVS erase).
 
 ## Updating (OTA)
 
-After the first serial flash, firmware is updated over WiFi — no cable. On the
-web page use **Firmware update**: pick the `dist/betaflight-bridge-<board>.bin`
-built for this board and hit *Upload & reboot*. The image streams into the spare OTA slot, the boot partition
-is switched, and the board restarts (~10 s); reconnect to the page afterwards.
+After the first flash, firmware is updated over WiFi — no cable. On the web page
+use **Firmware update**: pick the plain `betaflight-bridge-<board>.bin` built for
+this board — *not* the `-factory.bin`, which is a whole-flash image and is
+rejected — and hit *Upload & reboot*. The image streams into the spare OTA slot,
+the boot partition is switched, and the board restarts (~10 s); reconnect to the
+page afterwards.
 
 The layout is dual-OTA (`ota_0`/`ota_1`) with rollback enabled: a freshly
 uploaded image boots in *pending-verify* state and only sticks once it comes up
@@ -250,8 +294,9 @@ therefore checked on upload: an image for another board is rejected with a 400
 and the boot partition is left untouched. The running board and slot are shown
 on the status page.
 
-> The dual-OTA partition table only takes effect from a **serial** flash, so the
-> initial `idf.py ... flash` is the last one that needs the cable.
+> The partition table only takes effect from a flash over the wire, so the first
+> flash — `idf.py flash` or the factory image from a browser — is the last one
+> that needs the cable.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -186,8 +186,9 @@ The factory image needs no toolchain and no clone — download
 `betaflight-bridge-<board>-factory.bin` for your board from the
 [releases page](../../releases) and flash it at offset `0x0`:
 
-1. Open <https://espressif.github.io/esptool-js/> in Chrome or Edge (Web Serial
-   is not available in Firefox or Safari).
+1. Open <https://espressif.github.io/esptool-js/> in a browser that supports Web
+   Serial — Chrome/Edge 89+, Opera 76+, Firefox 151+, or Chrome on Android 152+.
+   Safari does not support it.
 2. **Connect**, and pick the board's port.
 3. Set the offset to `0x0`, choose the factory `.bin`, then **Program**.
 

--- a/README.md
+++ b/README.md
@@ -163,12 +163,17 @@ reconfigure, so you don't need to delete `sdkconfig` by hand.
 
 | File | Offset | Use |
 |------|--------|-----|
-| `betaflight-bridge-<board>.bin` | `0x20000` | OTA update from the web UI |
-| `betaflight-bridge-<board>-factory.bin` | `0x0` | first flash of a stock board |
+| `betaflight-bridge-<board>[-<version>].bin` | `0x20000` | OTA update from the web UI |
+| `betaflight-bridge-<board>[-<version>]-factory.bin` | `0x0` | first flash of a stock board |
 
 The factory image is the app plus the bootloader, partition table and a blank
 otadata/NVS, merged into one blob — everything a bare board needs. The plain
 image is the app alone, which is what the OTA endpoint expects.
+
+The `-<version>` suffix is the `BRIDGE_VERSION` in `src/main/version.h`, so a
+plain `make <board>` already stamps it. Override it with `make <board>
+VERSION=x.y.z` — the release workflow passes the tag. Examples below use
+`2026.6.0` in place of the version.
 
 To flash and monitor over serial, use `idf.py` directly:
 
@@ -183,7 +188,7 @@ single-port ZERO the console drops once host mode engages.
 ## First flash from a browser
 
 The factory image needs no toolchain and no clone — download
-`betaflight-bridge-<board>-factory.bin` for your board from the
+`betaflight-bridge-<board>-<version>-factory.bin` for your board from the
 [releases page](../../releases) and flash it at offset `0x0`:
 
 1. Open <https://espressif.github.io/esptool-js/> in a browser that supports Web
@@ -195,7 +200,8 @@ The factory image needs no toolchain and no clone — download
 Or, with esptool installed locally:
 
 ```sh
-esptool.py --chip esp32s3 write_flash 0x0 betaflight-bridge-<board>-factory.bin
+esptool.py --chip esp32s3 write_flash 0x0 \
+    betaflight-bridge-esp32s3-wroom-freenove-2026.6.0-factory.bin
 ```
 
 Afterwards the board is updated over WiFi — see [Updating](#updating-ota).
@@ -278,9 +284,10 @@ the bridge's IP changes or the certificate is cleared (e.g. an NVS erase).
 ## Updating (OTA)
 
 After the first flash, firmware is updated over WiFi — no cable. On the web page
-use **Firmware update**: pick the plain `betaflight-bridge-<board>.bin` built for
-this board — *not* the `-factory.bin`, which is a whole-flash image and is
-rejected — and hit *Upload & reboot*. The image streams into the spare OTA slot,
+use **Firmware update**: pick the plain
+`betaflight-bridge-<board>-<version>.bin` built for this board — *not* the
+`-factory.bin`, which is a whole-flash image and is rejected — and hit
+*Upload & reboot*. The image streams into the spare OTA slot,
 the boot partition is switched, and the board restarts (~10 s); reconnect to the
 page afterwards.
 

--- a/src/main/http_status.c
+++ b/src/main/http_status.c
@@ -176,6 +176,8 @@ static const char PAGE[] =
     "function reboot(){if(!confirm('Restart the bridge?'))return;$('ctl').textContent='Restarting — back in ~10s.';"
     "fetch('/reboot',{method:'POST'}).catch(function(){});setTimeout(function(){location.reload()},12000)}"
     "function upload(){var f=$('fw').files[0];if(!f){$('up').textContent='Pick a .bin file.';return}"
+    // The factory image is a whole-flash blob; OTA takes the app-only .bin.
+    "if(/-factory\\.bin$/i.test(f.name)){$('up').textContent='That is the factory image — use the plain .bin for OTA.';return}"
     "var x=new XMLHttpRequest();x.open('POST','/update');"
     "x.upload.onprogress=function(e){if(e.lengthComputable)$('up').textContent='Uploading '+Math.round(e.loaded/e.total*100)+'%…'};"
     "x.onload=function(){$('up').textContent=x.status==200?'Update OK — rebooting, reconnect in ~10s.':'Update failed: '+x.responseText};"


### PR DESCRIPTION
Builds only published the app binary, which is meaningless at offset `0x20000` without a matching bootloader and partition table. The only documented first flash was "clone the repo and install ESP-IDF", so browser flashers such as [esptool-js](https://espressif.github.io/esptool-js/) or a simple `esptool.py` call could not bring up a stock board without needing to install the complete ESPIDF and build the firmware just so you could run `idf.py -DBOARD=$@ -p <PORT> flash monitor`.

## What this does

Each build now also emits `dist/betaflight-bridge-<board>[-<version>]-factory.bin` — the bootloader, partition table, blank otadata/NVS and the app merged into one blob, flashed at `0x0`.

| File | Offset | Use |
|------|--------|-----|
| `betaflight-bridge-<board>.bin` | `0x20000` | OTA update from the web UI |
| `betaflight-bridge-<board>-factory.bin` | `0x0` | first flash of a stock board |

- Offsets and flash mode/freq/size come from the build's own `flash_args`, so they track each board's partition table and flash size — nothing is hardcoded.
- A blank otadata makes the bootloader fall through to `ota_0`.
- The blank NVS means a factory flash resets the stored WiFi credentials and the self-signed TLS certificate. This is deliberate, and documented.
- The web UI now rejects a `*-factory.bin` upload, which the OTA endpoint would otherwise refuse with an opaque "cannot read image descriptor".
- `.github/workflows/build.yml` is untouched — its artifact and release globs are already `dist/betaflight-bridge-<board>*.bin`, so releases pick up both images and will carry six assets.

## Testing

Built all three boards in `espressif/idf:release-v5.4`. For each, verified the merged image structurally: bootloader magic and valid checksum/hash at `0x0`, partition-table magic at `0x8000`, blank NVS and otadata, the app byte-identical at `0x20000`, no trailing data, and the header flash size matching the board.

```
OK  esp32s3-touch-lcd-4b   1605040 bytes  flash=16MB
OK  esp32s3-wroom-freenove 1240480 bytes  flash=8MB
OK  esp32s3-zero           1228672 bytes  flash=4MB
```

On hardware (Freenove): flashed the factory image at `0x0` with esptool-js, reset, connected to the bridge SoftAP, configured WiFi, restarted. Tried to OTA the factory image — correctly blocked. OTA'd the app image — works, now running from `ota_1`.

## Not included

A hosted installer. Now that the factory images exist that is purely additive: a `manifest.json` per board plus an [ESP Web Tools](https://esphome.github.io/esp-web-tools/) page with a board picker, deployed to Pages by a job that pulls the release's factory bins so they are served same-origin.

I don't know if you want to go this way... if you do, I can add that onto this PR, or do a folloup. I have essentially the same thing setup for another project I've been slowly refactoring... you can flash either the update or the full "factory" firmware from any browser that supports WebSerial... which now includes Firefox. https://github.com/pfeerick/LilyGo-EPD-4-7-OWM-Weather-Display#installing-firmware

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Builds now produce a merged factory image alongside the standard OTA image.
  * Factory images can be flashed from a browser or command line at offset `0x0`.

* **Bug Fixes**
  * The web firmware uploader now prevents factory images from being used for OTA updates and provides guidance to select the standard image.

* **Documentation**
  * Updated build and flashing guidance explains image types, offsets, board matching, and NVS reset considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->